### PR TITLE
Add support for a rootPath for all apps

### DIFF
--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -32,6 +32,11 @@ in {
         type = types.str;
         description = "The destination branch of the generated applications.";
       };
+      rootPath = mkOption {
+        type = types.str;
+        default = "";
+        description = "The root path of all generated applications in the repository.";
+      };
     };
 
     extraFiles = mkOption {
@@ -120,7 +125,10 @@ in {
                 source = {
                   repoURL = cfg.target.repository;
                   targetRevision = cfg.target.branch;
-                  path = app.output.path;
+                  path = lib.path.subpath.join [
+                    cfg.target.rootPath 
+                    app.output.path
+                  ];
                 };
                 destination = {
                   server = "https://kubernetes.default.svc";


### PR DESCRIPTION
Thanks for making the project. It seems to perfectly align with our setup @dialohq. I'm now testing nixidy out in a sandbox cluster and needed this little change.

I want all of the apps to be on the same (main) branch. This PR adds an option to nixidy to allow that.