### PR TITLE
Merge specialArgs using recursiveUpdate()

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -23,11 +23,12 @@
         }
       ];
     specialArgs =
-      {
-        inherit pkgs;
-        lib = extendedLib;
-      }
-      // extraSpecialArgs;
+      lib.attrsets.recursiveUpdate
+        {
+          inherit pkgs;
+          lib = extendedLib;
+        }
+        extraSpecialArgs;
   };
 in {
   inherit (module) config;


### PR DESCRIPTION
Merge `specialArgs` and `extraSpecialArgs` using `recursiveUpdate` rather than a straight `(//)` merge. This allows users to inject additonal modules into the lib "namespace" without interfereing with the internal extendedLib definitions.