### PR TITLE
Fix implementation of fromYAML

### DIFF
--- a/lib/kube.nix
+++ b/lib/kube.nix
@@ -1,12 +1,10 @@
 {
   lib,
-  klib,
+  pkgs,
   ...
 }: {
   /*
   Parses a YAML document string into a list of attribute sets.
-
-  > This is re-exported directly from [farcaller/nix-kube-generators](https://github.com/farcaller/nix-kube-generators).
 
   Type:
     fromYAML :: String -> [AttrSet]
@@ -39,7 +37,18 @@
   fromYAML =
     # String with a yaml document.
     yaml:
-      klib.fromYAML yaml;
+      lib.pipe yaml [
+        (yaml: (pkgs.stdenv.mkDerivation {
+          inherit yaml;
+          passAsFile = "yaml";
+          name = "fromYAML";
+          phases = ["buildPhase"];
+          buildPhase = "${pkgs.yq}/bin/yq -Ms . $yamlPath > $out";
+        }))
+        builtins.readFile
+        builtins.fromJSON
+        (builtins.filter (v: v != null))
+      ];
 
   /*
   Parse an octal representation of a number and convert into a decimal number. This can be useful when having to represent permission bits in a resource as nix has no support for representing octal numbers.


### PR DESCRIPTION
Copy in `fromYAML` from nix-kube-generators to remove dependency on `busybox` which broke nixidy build on Mac OS.

Fixes #18 