### PR TITLE
Add support for flake-less nix

### DIFF
--- a/.github/workflows/cli-shellcheck.yaml
+++ b/.github/workflows/cli-shellcheck.yaml
@@ -1,12 +1,16 @@
-name: Statix check
+name: CLI shellcheck test
 
 on:
   push:
     branches:
       - main
+    paths:
+      - nixidy/**
   pull_request:
     branches:
       - main
+    paths:
+      - nixidy/**
 
 jobs:
   static-lint:
@@ -23,4 +27,4 @@ jobs:
 
     - name: Run statix
       run: |
-        nix run .#staticCheck
+        nix run .#cliTest

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,41 @@
+{nixpkgs ? null}: let
+  flakeLock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  flakeLockMeta = node: let
+    lock = flakeLock.nodes.${node}.locked;
+  in {
+    inherit (lock) owner repo rev type;
+    hash = lock.narHash;
+  };
+
+  npkgs = let
+    meta = flakeLockMeta "nixpkgs";
+
+    source =
+      if nixpkgs == null
+      then
+        builtins.fetchTarball {
+          url = "https://github.com/${meta.owner}/${meta.repo}/archive/${meta.rev}.tar.gz";
+          sha256 = meta.hash;
+        }
+      else nixpkgs;
+  in
+    import source {};
+
+  importFromFlakeLock = node: let
+    lock = flakeLockMeta node;
+  in
+    if lock.type == "github"
+    then npkgs.fetchFromGitHub (removeAttrs lock ["type"])
+    else throw "fetcher for type ${lock.type} unsupported";
+
+  kubenix = importFromFlakeLock "kubenix";
+  kubelib = importFromFlakeLock "nix-kube-generators";
+
+  lib = import ./make-env.nix {inherit kubenix kubelib;};
+in {
+  lib = {
+    mkEnv = args @ {pkgs ? npkgs, ...}: lib.mkEnv (args // {inherit pkgs;});
+    mkEnvs = args @ {pkgs ? npkgs, ...}: lib.mkEnvs (args // {inherit pkgs;});
+  };
+}

--- a/docs/docs.nix
+++ b/docs/docs.nix
@@ -69,6 +69,7 @@
         - pymdownx.highlight
         - pymdownx.inlinehilite
         - pymdownx.superfences
+        - pymdownx.details
         - pymdownx.tabbed:
             alternate_style: true
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,48 +20,9 @@
     kubenix,
   }:
     {
-      lib = rec {
-        mkEnv = {
-          pkgs,
-          lib ? pkgs.lib,
-          modules ? [],
-          extraSpecialArgs ? {},
-          charts ? {},
-          libOverlay ? null,
-        }:
-          import ./modules {
-            inherit pkgs lib extraSpecialArgs kubenix libOverlay;
-            kubelib = nix-kube-generators;
-            modules =
-              modules
-              ++ [
-                {
-                  nixidy.charts = charts;
-                }
-              ];
-          };
-
-        mkEnvs = {
-          pkgs,
-          lib ? pkgs.lib,
-          modules ? [],
-          extraSpecialArgs ? {},
-          envs ? {},
-          charts ? {},
-          libOverlay ? null,
-        }:
-          lib.mapAttrs (
-            env: conf:
-              mkEnv {
-                inherit pkgs lib charts libOverlay;
-                extraSpecialArgs = extraSpecialArgs // (conf.extraSpecialArgs or {});
-                modules =
-                  [{nixidy.target.rootPath = lib.mkDefault "./manifests/${env}";}]
-                  ++ modules
-                  ++ (conf.modules or []);
-              }
-          )
-          envs;
+      lib = import ./make-env.nix {
+        inherit kubenix;
+        kubelib = nix-kube-generators;
       };
     }
     // (flake-utils.lib.eachDefaultSystem (system: let

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,26 @@
           type = "app";
           program = self.moduleTests.${system}.reportScript.outPath;
         };
+
+        # Run shellcheck on nixidy cli
+        cliTest = {
+          type = "app";
+          program =
+            (pkgs.writeShellScript "cli-shellcheck-test" ''
+              ${pkgs.shellcheck}/bin/shellcheck ${self.packages.${system}.default}/bin/nixidy
+            '')
+            .outPath;
+        };
+
+        # Serve docs
+        docsServe = {
+          type = "app";
+          program =
+            (pkgs.writeShellScript "serve-docs" ''
+              ${pkgs.python3}/bin/python -m http.server -d ${(import ./docs {inherit pkgs;}).html} 8080
+            '')
+            .outPath;
+        };
       };
     }));
 }

--- a/make-env.nix
+++ b/make-env.nix
@@ -1,0 +1,45 @@
+{
+  kubenix,
+  kubelib,
+}: rec {
+  mkEnv = {
+    pkgs,
+    lib ? pkgs.lib,
+    modules ? [],
+    extraSpecialArgs ? {},
+    charts ? {},
+    libOverlay ? null,
+  }:
+    import ./modules {
+      inherit pkgs lib extraSpecialArgs kubenix kubelib libOverlay;
+      modules =
+        modules
+        ++ [
+          {
+            nixidy.charts = charts;
+          }
+        ];
+    };
+
+  mkEnvs = {
+    pkgs,
+    lib ? pkgs.lib,
+    modules ? [],
+    extraSpecialArgs ? {},
+    envs ? {},
+    charts ? {},
+    libOverlay ? null,
+  }:
+    lib.mapAttrs (
+      env: conf:
+        mkEnv {
+          inherit pkgs lib charts libOverlay;
+          extraSpecialArgs = extraSpecialArgs // (conf.extraSpecialArgs or {});
+          modules =
+            [{nixidy.target.rootPath = lib.mkDefault "./manifests/${env}";}]
+            ++ modules
+            ++ (conf.modules or []);
+        }
+    )
+    envs;
+}

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -128,7 +128,7 @@ in {
 
           # We need to check if there is a difference between
           # the newly built environment and the destination
-          # excluding `.revision` because that will most likely
+          # excluding ".revision" because that will most likely
           # always change when going through CI, avoiding infinite
           # loop.
           if ! ${pkgs.diffutils}/bin/diff -q -r --exclude .revision "${config.build.environmentPackage}" "\$dest" &>/dev/null; then

--- a/nixidy/nixidy
+++ b/nixidy/nixidy
@@ -6,11 +6,11 @@ PATH=@DEP_PATH@${PATH:+:}$PATH
 set -euo pipefail
 
 function setFlakeParam() {
-  local flake="${FLAKE_PARAM%#*}"
+  local flake="${ENV_PARAM%#*}"
 
-  case $FLAKE_PARAM in
+  case $ENV_PARAM in
     *#*)
-      local env="${FLAKE_PARAM#*#}"
+      local env="${ENV_PARAM#*#}"
       ;;
     *)
       local env=""
@@ -19,9 +19,34 @@ function setFlakeParam() {
 
   export FLAKE_ROOT="$flake"
   export FLAKE_ENV="$env"
+  export NIX_SYSTEM=$(nix eval --expr builtins.currentSystem --raw --impure)
 }
 
 function doInfo() {
+  if [[ "$USE_FLAKE" == true ]]; then
+    doInfoFlake
+  else
+    doInfoAttr
+  fi
+}
+
+function doInfoAttr() {
+  if [[ -z $ENV_PARAM ]]; then
+    doHelp
+    exit 1
+  fi
+
+  local info=$(nix-instantiate --eval --strict --json "$FILE_PARAM" -A "$ENV_PARAM.meta")
+
+  if [[ "$INFO_JSON" == "true" ]]; then
+    echo $info
+  else
+    echo "Repository: $(echo "$info" | jq -r .repository)"
+    echo "Branch:     $(echo "$info" | jq -r .branch)"
+  fi
+}
+
+function doInfoFlake() {
   setFlakeParam
 
   if [[ -z "$FLAKE_ENV" ]]; then
@@ -40,6 +65,23 @@ function doInfo() {
 }
 
 function doBuild() {
+  if [[ "$USE_FLAKE" == true ]]; then
+    doBuildFlake
+  else
+    doBuildAttr
+  fi
+}
+
+function doBuildAttr() {
+  if [[ -z $ENV_PARAM ]]; then
+    doHelp
+    exit 1
+  fi
+
+  nix-build "$FILE_PARAM" -A "$ENV_PARAM.environmentPackage" "${BUILD_PARAMS[@]}"
+}
+
+function doBuildFlake() {
   setFlakeParam
 
   if [[ -z "$FLAKE_ENV" ]]; then
@@ -51,6 +93,26 @@ function doBuild() {
 }
 
 function doSwitch() {
+  if [[ "$USE_FLAKE" == true ]]; then
+    doSwitchFlake
+  else
+    doSwitchAttr
+  fi
+}
+
+function doSwitchAttr() {
+  if [[ -z $ENV_PARAM ]]; then
+    doHelp
+    exit 1
+  fi
+
+  # TODO: set link path
+  ENVIRON=$(nix-build "$FILE_PARAM" -A "$ENV_PARAM.activationPackage")
+
+  "result/activate"
+}
+
+function doSwitchFlake() {
   setFlakeParam
 
   if [[ -z "$FLAKE_ENV" ]]; then
@@ -109,7 +171,9 @@ function doHelp() {
 }
 
 COMMAND=""
-FLAKE_PARAM=""
+USE_FLAKE=true
+ENV_PARAM=""
+FILE_PARAM=""
 
 BUILD_PARAMS=()
 INFO_JSON="false"
@@ -134,12 +198,16 @@ while [[ $# -gt 0 ]]; do
     --json)
       INFO_JSON="true"
       ;;
+    -f|--file)
+      FILE_PARAM="$1"
+      USE_FLAKE=false
+      ;;
     -h|--help)
       doHelp
       exit 0
       ;;
     *)
-      FLAKE_PARAM="$opt"
+      ENV_PARAM="$opt"
       ;;
   esac
 done
@@ -148,12 +216,6 @@ if [[ -z $COMMAND ]]; then
     doHelp >&2
     exit 1
 fi
-
-if [[ -z $FLAKE_PARAM ]]; then
-  FLAKE_PARAM=".#"
-fi
-
-NIX_SYSTEM=$(nix eval --expr builtins.currentSystem --raw --impure)
 
 case $COMMAND in
   info)

--- a/nixidy/nixidy
+++ b/nixidy/nixidy
@@ -17,9 +17,13 @@ function setFlakeParam() {
       ;;
   esac
 
-  export FLAKE_ROOT="$flake"
-  export FLAKE_ENV="$env"
-  export NIX_SYSTEM=$(nix eval --expr builtins.currentSystem --raw --impure)
+  FLAKE_ROOT="$flake"
+  FLAKE_ENV="$env"
+  NIX_SYSTEM=$(nix eval --expr builtins.currentSystem --raw --impure)
+
+  export FLAKE_ROOT
+  export FLAKE_ENV
+  export NIX_SYSTEM
 }
 
 function doInfo() {
@@ -36,10 +40,11 @@ function doInfoAttr() {
     exit 1
   fi
 
-  local info=$(nix-instantiate --eval --strict --json "$FILE_PARAM" -A "$ENV_PARAM.meta")
+  local info
+  info=$(nix-instantiate --eval --strict --json "$FILE_PARAM" -A "$ENV_PARAM.meta")
 
   if [[ "$INFO_JSON" == "true" ]]; then
-    echo $info
+    echo "$info"
   else
     echo "Repository: $(echo "$info" | jq -r .repository)"
     echo "Branch:     $(echo "$info" | jq -r .branch)"
@@ -47,17 +52,16 @@ function doInfoAttr() {
 }
 
 function doInfoFlake() {
-  setFlakeParam
-
   if [[ -z "$FLAKE_ENV" ]]; then
     doHelp
     exit 1
   fi
 
-  local info=$(nix eval "${FLAKE_ROOT}#nixidyEnvs.${NIX_SYSTEM}.${FLAKE_ENV}.meta" --json)
+  local info
+  info=$(nix eval "${FLAKE_ROOT}#nixidyEnvs.${NIX_SYSTEM}.${FLAKE_ENV}.meta" --json)
 
   if [[ "$INFO_JSON" == "true" ]]; then
-    echo $info
+    echo "$info"
   else
     echo "Repository: $(echo "$info" | jq -r .repository)"
     echo "Branch:     $(echo "$info" | jq -r .branch)"
@@ -82,8 +86,6 @@ function doBuildAttr() {
 }
 
 function doBuildFlake() {
-  setFlakeParam
-
   if [[ -z "$FLAKE_ENV" ]]; then
     doHelp
     exit 1
@@ -106,15 +108,12 @@ function doSwitchAttr() {
     exit 1
   fi
 
-  # TODO: set link path
-  ENVIRON=$(nix-build "$FILE_PARAM" -A "$ENV_PARAM.activationPackage")
+  ENVIRON=$(nix-build "$FILE_PARAM" -A "$ENV_PARAM.activationPackage" --no-link)
 
-  "result/activate"
+  "${ENVIRON}/activate"
 }
 
 function doSwitchFlake() {
-  setFlakeParam
-
   if [[ -z "$FLAKE_ENV" ]]; then
     doHelp
     exit 1
@@ -126,8 +125,28 @@ function doSwitchFlake() {
 }
 
 function doBootstrap() {
-  setFlakeParam
+  if [[ "$USE_FLAKE" == true ]]; then
+    doBootstrapFlake
+  else
+    doBootstrapAttr
+  fi
+}
 
+function doBootstrapAttr() {
+  if [[ -z $ENV_PARAM ]]; then
+    doHelp
+    exit 1
+  fi
+
+  BOOTSTRAP=$(nix-build "$FILE_PARAM" -A "$ENV_PARAM.bootstrapPackage" --no-link)
+
+  for manifest in "$BOOTSTRAP"/*.yaml; do
+    echo "---"
+    cat "$manifest"
+  done
+}
+
+function doBootstrapFlake() {
   if [[ -z "$FLAKE_ENV" ]]; then
     doHelp
     exit 1
@@ -135,9 +154,9 @@ function doBootstrap() {
 
   BOOTSTRAP=$(nix build "${FLAKE_ROOT}#nixidyEnvs.${NIX_SYSTEM}.${FLAKE_ENV}.bootstrapPackage" --no-link --print-out-paths)
 
-  for manifest in "$BOOTSTRAP/*.yaml"; do
+  for manifest in "$BOOTSTRAP"/*.yaml; do
     echo "---"
-    cat $manifest
+    cat "$manifest"
   done
 }
 
@@ -150,23 +169,34 @@ function doHelp() {
     echo "  --out-link PATH    Create a custom result symlink (only used in build)."
     echo "  --print-out-paths  Print the resulting output paths (only used in build)."
     echo "  --json             Output info in JSON format (only used in info)."
+    echo "  -f, --file PATH    Specify path to entrypoint nix file (only flake-less)."
     echo "  -h                 Print this help"
+    echo
+    echo "ENV parameter"
+    echo
+    echo "  All sub-commands take an \`ENV\` parameter, this parameter is used to"
+    echo "  determine if flakes or flake-less nix should be used and which environment"
+    echo "  should be built."
+    echo
+    echo "  Example:"
+    echo "  - \`.#prod\`:  Uses a flake in the local directory."
+    echo "  - \`prod\`:    Does not use flake but builds the \`prod\` environment in"
+    echo "               \`default.nix\` by default (can be overridden with --file)."
     echo
     echo "Commands"
     echo
     echo "  help             Print this help."
     echo
-    echo "  info FLAKE_URI   Get info about environment."
+    echo "  info ENV         Get info about environment."
     echo "                   Example: .#prod"
     echo
-    echo "  build FLAKE_URI  Build nixidy environment from flake URI."
+    echo "  build ENV        Build nixidy environment from flake URI."
     echo "                   Example: .#prod"
     echo
-    echo "  switch FLAKE_URI Build and switch to nixidy environment from flake URI."
+    echo "  switch ENV       Build and switch to nixidy environment from flake URI."
     echo "                   Example: .#prod"
     echo
-    echo "  bootstrap FLAKE_URI"
-    echo "                   Output a manifest to bootstrap appOfApps."
+    echo "  bootstrap ENV    Output a manifest to bootstrap appOfApps."
     echo "                   Example: .#prod"
 }
 
@@ -215,6 +245,13 @@ done
 if [[ -z $COMMAND ]]; then
     doHelp >&2
     exit 1
+fi
+
+# Detect if we should use a flake or flake-less approach
+if [[ $ENV_PARAM =~ ^[a-zA-Z0-9\:\/\.]+#[a-zA-Z0-9\.]*$ ]]; then
+  setFlakeParam
+else
+  USE_FLAKE=false
 fi
 
 case $COMMAND in


### PR DESCRIPTION
There's been a pretty polarizing discussion about flakes vs non-flakes in the nix community.

After being reminded of the the user base that does not want to use flakes (it is behind an opt-in `--experimental-features` flag after all) I decided to add support for using a regular old `default.nix` file to use nixidy.