### PR TITLE
Handle a specific case of anyOf

### DIFF
--- a/pkgs/generators/crd2jsonschema.py
+++ b/pkgs/generators/crd2jsonschema.py
@@ -65,9 +65,13 @@ def generate_jsonschema(files):
             if 'type' in definition and definition['type'] == 'object':
                 if not 'properties' in definition:
                     if 'additionalProperties' in definition:
-                        # The nix generator doesn't support anyOf
                         if 'anyOf' in definition['additionalProperties']:
-                            definition['additionalProperties'] = definition['additionalProperties']['anyOf'][0]
+                            if definition['additionalProperties'].get('x-kubernetes-int-or-string', False):
+                                # Patch the definition based on the custom x-kubernetes-int-or-string
+                                definition['additionalProperties'] = { 'type': 'string', 'format': 'int-or-string' }
+                            else:
+                                # The nix generator doesn't support anyOf
+                                definition['additionalProperties'] = definition['additionalProperties']['anyOf'][0]
 
                         # If additionalProperties only contains 'x-kubernetes-preserve-unknown-fields'
                         # we can just drop the `additionalProperties` entirely and the generator


### PR DESCRIPTION
The `anyOf` handling was not considering a case that's already coded in the kubenix generator, the int-or-string case.

For reasons beyond my current knowledge, the CRDs I'm using (Cloudnative-PG) contain a property called `x-kubernetes-int-or-string` and not the expected `int-or-string` in the `format` property inside the `type`.

This PR handles this case by patching up the definition so that the generator uses `either int str` instead of blindly picking the first one.