### PR TITLE
Add more options to applications module

### DIFF
--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -263,6 +263,54 @@ in {
         '';
       };
     };
+    ignoreDifferences = let
+      submoduleType = types.submodule ({name, ...}: {
+        options = {
+          group = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+          jqPathExpressions = mkOption {
+            description = "";
+            type = types.nullOr (types.listOf types.str);
+          };
+          jsonPointers = mkOption {
+            description = "";
+            type = types.nullOr (types.listOf types.str);
+          };
+          kind = mkOption {
+            description = "";
+            type = types.str;
+          };
+          managedFieldsManagers = mkOption {
+            description = "ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the\ndesired state defined in the SCM and won't be displayed in diffs";
+            type = types.nullOr (types.listOf types.str);
+          };
+          name = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+          namespace = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+        };
+
+        config = {
+          "group" = mkOverride 1002 null;
+          "jqPathExpressions" = mkOverride 1002 null;
+          "jsonPointers" = mkOverride 1002 null;
+          "managedFieldsManagers" = mkOverride 1002 null;
+          "name" = mkOverride 1002 null;
+          "namespace" = mkOverride 1002 null;
+        };
+      });
+    in
+      mkOption {
+        type = with types; nullOr (listOf submoduleType);
+        description = "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison";
+        default = null;
+      };
     objects = mkOption {
       type = with types; listOf attrs;
       apply = unique;

--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -164,6 +164,22 @@ in {
           '';
         };
       };
+      managedNamespaceMetadata = {
+        labels = mkOption {
+          type = types.attrsOf types.str;
+          default = {};
+          description = ''
+            Labels to apply to the managed namespace when created by Argo CD.
+          '';
+        };
+        annotations = mkOption {
+          type = types.attrsOf types.str;
+          default = {};
+          description = ''
+            Annotations to apply to the managed namespace when created by Argo CD.
+          '';
+        };
+      };
       syncOptions = {
         applyOutOfSyncOnly = mkOption {
           type = types.bool;
@@ -235,6 +251,19 @@ in {
             resources defined in the yamls are already applied by another Application. If the `failOnSharedResource` sync option
             is set, Argo CD will fail the sync whenever it finds a resource in the current Application that is already applied in
             the cluster by another Application.
+          '';
+        };
+        createNamespace = mkOption {
+          type = types.bool;
+          default = false;
+          apply = val:
+            if val
+            then "CreateNamespace=true"
+            else null;
+          description = ''
+            Argo CD Application can be configured so it will create the namespace specified in spec.destination.namespace if it doesn't exist already. Without this either declared in the Application manifest or passed in the CLI via --sync-option CreateNamespace=true, the Application will fail to sync if the namespace doesn't exist.
+
+            Note that the namespace to be created must be informed in the spec.destination.namespace field of the Application resource. The metadata.namespace field in the Application's child manifests must match this value, or can be omitted, so resources are created in the proper destination.
           '';
         };
       };

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -220,6 +220,7 @@ in {
                     // (lib.optionalAttrs (lib.length app.syncPolicy.finalSyncOpts > 0) {
                       syncOptions = app.syncPolicy.finalSyncOpts;
                     });
+                  inherit (app) ignoreDifferences;
                 };
               };
             }

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -219,6 +219,11 @@ in {
                     })
                     // (lib.optionalAttrs (lib.length app.syncPolicy.finalSyncOpts > 0) {
                       syncOptions = app.syncPolicy.finalSyncOpts;
+                    })
+                    // (lib.optionalAttrs (app.syncPolicy.managedNamespaceMetadata.labels != {} || app.syncPolicy.managedNamespaceMetadata.annotations != {}) {
+                      managedNamespaceMetadata = lib.filterAttrs (_: v: v != {}) {
+                        inherit (app.syncPolicy.managedNamespaceMetadata) labels annotations;
+                      };
                     });
                   inherit (app) ignoreDifferences;
                 };


### PR DESCRIPTION
This PR adds those options to `applications` module:
* `ignoreDifferences`
* `managedNamespaceMetadata` inside the `syncPolicy`
* `createNamespace` inside the `syncPolicy.syncOptions`

This changes were made mainly to match some values originally generated by an operator (especially the `createNamespace` sync option which doesn't really make sense in normal cases). Seems like it's working fine with all the types. I didn't have time to write any tests for those options though and I'm not sure if this code fits well, so I'm open for any comments and I can do some cleanup later.

