### PR TITLE
Add ignoreDifferences options to application module

### DIFF
--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -268,14 +268,17 @@ in {
         options = {
           group = mkOption {
             description = "";
+            default = null;
             type = types.nullOr types.str;
           };
           jqPathExpressions = mkOption {
             description = "";
+            default = null;
             type = types.nullOr (types.listOf types.str);
           };
           jsonPointers = mkOption {
             description = "";
+            default = null;
             type = types.nullOr (types.listOf types.str);
           };
           kind = mkOption {
@@ -284,30 +287,24 @@ in {
           };
           managedFieldsManagers = mkOption {
             description = "ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the\ndesired state defined in the SCM and won't be displayed in diffs";
+            default = null;
             type = types.nullOr (types.listOf types.str);
           };
           name = mkOption {
             description = "";
+            default = null;
             type = types.nullOr types.str;
           };
           namespace = mkOption {
             description = "";
+            default = null;
             type = types.nullOr types.str;
           };
-        };
-
-        config = {
-          "group" = mkOverride 1002 null;
-          "jqPathExpressions" = mkOverride 1002 null;
-          "jsonPointers" = mkOverride 1002 null;
-          "managedFieldsManagers" = mkOverride 1002 null;
-          "name" = mkOverride 1002 null;
-          "namespace" = mkOverride 1002 null;
         };
       });
     in
       mkOption {
-        type = with types; nullOr (listOf submoduleType);
+        type = with types; nullOr (attrsOf submoduleType);
         description = "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison";
         default = null;
       };

--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -263,6 +263,54 @@ in {
         '';
       };
     };
+    ignoreDifferences = let
+      submoduleType = types.submodule ({name, ...}: {
+        options = {
+          group = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+          jqPathExpressions = mkOption {
+            description = "";
+            type = types.nullOr (types.listOf types.str);
+          };
+          jsonPointers = mkOption {
+            description = "";
+            type = types.nullOr (types.listOf types.str);
+          };
+          kind = mkOption {
+            description = "";
+            type = types.str;
+          };
+          managedFieldsManagers = mkOption {
+            description = "ManagedFieldsManagers is a list of trusted managers. Fields mutated by those managers will take precedence over the\ndesired state defined in the SCM and won't be displayed in diffs";
+            type = types.nullOr (types.listOf types.str);
+          };
+          name = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+          namespace = mkOption {
+            description = "";
+            type = types.nullOr types.str;
+          };
+        };
+
+        config = {
+          "group" = mkOverride 1002 null;
+          "jqPathExpressions" = mkOverride 1002 null;
+          "jsonPointers" = mkOverride 1002 null;
+          "managedFieldsManagers" = mkOverride 1002 null;
+          "name" = mkOverride 1002 null;
+          "namespace" = mkOverride 1002 null;
+        };
+      });
+    in
+      mkOption {
+        type = with types; nullOr (listOf submoduleType);
+        description = "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison";
+        default = null;
+      };
     objects = mkOption {
       type = with types; listOf attrs;
       apply = unique;

--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -283,6 +283,7 @@ in {
           };
           kind = mkOption {
             description = "";
+            default = name;
             type = types.str;
           };
           managedFieldsManagers = mkOption {
@@ -305,7 +306,11 @@ in {
     in
       mkOption {
         type = with types; nullOr (attrsOf submoduleType);
-        description = "IgnoreDifferences is a list of resources and their fields which should be ignored during comparison";
+        description = ''
+          IgnoreDifferences is a list of resources and their fields which should be ignored during comparison.
+
+          More info [here](https://argo-cd.readthedocs.io/en/stable/user-guide/diffing/).
+        '';
         default = null;
       };
     objects = mkOption {

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -197,7 +197,7 @@ in {
                     else null;
                 };
                 spec = {
-                  inherit (app) project;
+                  inherit (app) project ignoreDifferences;
 
                   source = {
                     repoURL = cfg.target.repository;
@@ -220,11 +220,6 @@ in {
                     // (lib.optionalAttrs (lib.length app.syncPolicy.finalSyncOpts > 0) {
                       syncOptions = app.syncPolicy.finalSyncOpts;
                     });
-
-                  ignoreDifferences =
-                    if builtins.isAttrs app.ignoreDifferences
-                    then lib.mapAttrsToList (kind: value: value // {inherit kind;}) app.ignoreDifferences
-                    else null;
                 };
               };
             }

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -220,6 +220,7 @@ in {
                     // (lib.optionalAttrs (lib.length app.syncPolicy.finalSyncOpts > 0) {
                       syncOptions = app.syncPolicy.finalSyncOpts;
                     });
+                  inherit (app) ignoreDifferences;
                 };
               };
             }

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -220,7 +220,11 @@ in {
                     // (lib.optionalAttrs (lib.length app.syncPolicy.finalSyncOpts > 0) {
                       syncOptions = app.syncPolicy.finalSyncOpts;
                     });
-                  inherit (app) ignoreDifferences;
+
+                  ignoreDifferences =
+                    if builtins.isAttrs app.ignoreDifferences
+                    then lib.mapAttrsToList (kind: value: value // {inherit kind;}) app.ignoreDifferences
+                    else null;
                 };
               };
             }


### PR DESCRIPTION
Continuation of #32

As request, I changed the way of defining default values and changed the whole type of `ignoreDifferences` option to attribute set which is then transformed into a list.

Open for any comments or requests.