### PR TITLE
fix: avoid attrName collisions breaking evaluation

### DIFF
--- a/pkgs/generators/crd.nix
+++ b/pkgs/generators/crd.nix
@@ -4,6 +4,7 @@
   name,
   src,
   crds,
+  attrNameOverrides,
 }: let
   # The nix code generator is slightly modified from kubenix's
   # generator and as it kind of depends on the jsonschema to be
@@ -22,7 +23,7 @@
       phases = ["unpackPhase" "installPhase"];
 
       installPhase = ''
-        ${pythonWithYaml}/bin/python ${./crd2jsonschema.py} ${lib.concatStringsSep " " crds} > $out
+        ${pythonWithYaml}/bin/python ${./crd2jsonschema.py} "${builtins.toJSON attrNameOverrides}" ${lib.concatStringsSep " " crds} > $out
       '';
     };
 in

--- a/pkgs/generators/crd2jsonschema.py
+++ b/pkgs/generators/crd2jsonschema.py
@@ -29,7 +29,7 @@ def gen_attr_name(kind, plural):
 def uppercase_first(name):
     return name[0].upper() + name[1:]
 
-def generate_jsonschema(files):
+def generate_jsonschema(files, attr_name_overrides):
     schema = {'definitions': {}, 'roots': []}
 
     for file in files:
@@ -55,7 +55,7 @@ def generate_jsonschema(files):
                                                'version': version,
                                                'kind': kind,
                                                'name': plural,
-                                               'attrName': gen_attr_name(kind, plural),
+                                               'attrName': attr_name_overrides.get(definitionKey, gen_attr_name(kind, plural)),
                                                'description': ver['schema']['openAPIV3Schema'].get('description', ''),
                                                'namespaced': namespaced,
                                            })
@@ -134,6 +134,6 @@ def generate_jsonschema(files):
     return schema
 
 if __name__ == "__main__":
-    files = sys.argv[1:]
-    schema = generate_jsonschema(files)
+    [attr_name_overrides, *files] = sys.argv[1:]
+    schema = generate_jsonschema(files, json.loads(attr_name_overrides))
     print(json.dumps(schema, indent=2))

--- a/pkgs/generators/default.nix
+++ b/pkgs/generators/default.nix
@@ -6,9 +6,13 @@
     name,
     src,
     crds,
+    # Mapping of CRD definitionKey to attrName
+    # Useful to avoid breaking collisions or shorten long type names
+    # Ex: {"authenticationflow.keycloak.crossplane.io.v1alpha1.Bindings" = "keycloakBindings";}
+    attrNameOverrides ? {},
   }:
     import ./crd.nix {
-      inherit pkgs lib name src crds;
+      inherit pkgs lib name src crds attrNameOverrides;
     };
 in {
   inherit fromCRD;


### PR DESCRIPTION
attrNameOverrides is a basic mapping of a CRD's definitionKey to a new attrName provided as an argument to packages.generators.fromCRD. This was motivated by a collision that broke evaluation due to a repeated option declaration, but it could be use to create an even shorter attrName for particularly long resource type names.