### PR TITLE
fix: removeLabels with explicit metadata.labels = null in manifest

### DIFF
--- a/lib/kube.nix
+++ b/lib/kube.nix
@@ -107,7 +107,7 @@
     in
       lib.attrsets.updateManyAttrsByPath (
         # If metadata.labels is present, it should be filtered
-        (lib.optional (manifest.metadata ? labels) {
+        (lib.optional (hasLabelPath ["metadata" "labels"] manifest) {
           path = ["metadata" "labels"];
           update = updateFunc;
         })


### PR DESCRIPTION
I encountered a manifest with `metadata.labels` explicitly set to null, and this broke `removeLabels` because the value of `old` in `removeAttrs old labels` must be a set, not null. `hasLabelPath` already accounts for this situation well for other update branches, so it might as well be used for this one too.