### PR TITLE
feat: fromCRD attrNameOverrides

### DIFF
--- a/pkgs/generators/crd/crd2jsonschema.py
+++ b/pkgs/generators/crd/crd2jsonschema.py
@@ -36,7 +36,7 @@ def uppercase_first(name):
     return name[0].upper() + name[1:]
 
 
-def generate_jsonschema(prefix, files):
+def generate_jsonschema(prefix, files, attr_name_overrides):
     schema = {"definitions": {}, "roots": []}
 
     for file in files:
@@ -67,7 +67,7 @@ def generate_jsonschema(prefix, files):
                             "version": version,
                             "kind": kind,
                             "name": plural,
-                            "attrName": gen_attr_name(kind, plural, prefix),
+                            "attrName": attr_name_overrides.get(data["metadata"]["name"], gen_attr_name(kind, plural, prefix)),
                             "description": ver["schema"]["openAPIV3Schema"].get(
                                 "description", ""
                             ),
@@ -180,6 +180,7 @@ if __name__ == "__main__":
 
     prefix = options.get("namePrefix", "")
     files = options.get("crds", [])
+    attr_name_overrides = options.get("attrNameOverrides", {})
 
-    schema = generate_jsonschema(prefix, files)
+    schema = generate_jsonschema(prefix, files, attr_name_overrides)
     print(json.dumps(schema, indent=2))

--- a/pkgs/generators/crd/default.nix
+++ b/pkgs/generators/crd/default.nix
@@ -5,9 +5,10 @@
   src,
   crds,
   namePrefix,
+  attrNameOverrides,
 }: let
   options = pkgs.writeText "${name}-crd2jsonschema-options.json" (builtins.toJSON {
-    inherit crds namePrefix;
+    inherit crds namePrefix attrNameOverrides;
   });
 
   # The nix code generator is slightly modified from kubenix's

--- a/pkgs/generators/default.nix
+++ b/pkgs/generators/default.nix
@@ -7,9 +7,10 @@
     src,
     crds,
     namePrefix ? "",
+    attrNameOverrides ? {},
   }:
     import ./crd/default.nix {
-      inherit pkgs lib name src crds namePrefix;
+      inherit pkgs lib name src crds namePrefix attrNameOverrides;
     };
 in {
   inherit fromCRD;


### PR DESCRIPTION
Fixes collisions that can come from the same CRD chart if there is overlap in plurals. This appears to be not that rare in the Crossplane world. It can also be used for really short names for commonly used resource types for ergonomics. This is the updated successor to #39.