### PR TITLE
fix: gen_attr_name don't break leading acronyms

### DIFF
--- a/pkgs/generators/crd/test_crd2jsonschema.py
+++ b/pkgs/generators/crd/test_crd2jsonschema.py
@@ -22,6 +22,11 @@ class TestGenAttrName(unittest.TestCase):
             "ciliumNetworkPolicies",
         )
 
+    def test_leading_acronym(self):
+        self.assertEqual(gen_attr_name("HTTPRoute", "httproutes", ""), "httpRoutes")
+
+    def test_leading_acronym_prefix(self):
+        self.assertEqual(gen_attr_name("HTTPRoute", "httproutes", "gateway"), "gatewayHTTPRoutes")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
I thought it was ugly but more importantly unexpected that the generated attrName for `HTTPRoute` was `hTTPRoutes`. This fix will lowercase an entire leading acronym if there is no prefix but otherwise retain acronyms.