### PR TITLE
feat: flatten *List objects in Helm/Kustomize

### DIFF
--- a/modules/applications/helm.nix
+++ b/modules/applications/helm.nix
@@ -94,6 +94,12 @@ in {
   };
 
   config = with lib; let
+    # Recursively flatten *List objects
+    flattenListObjects = builtins.concatMap (object:
+      if builtins.match "^.*List$" object.kind != null
+      then flattenListObjects object.items
+      else [object]
+    );
     groupedObjects = mapAttrs (_: release:
       {
         resources = [];
@@ -107,7 +113,7 @@ in {
             then "resources"
             else "objects"
         )
-        release.objects))
+        (flattenListObjects release.objects)))
     config.helm.releases;
 
     allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);

--- a/modules/applications/helm.nix
+++ b/modules/applications/helm.nix
@@ -94,12 +94,6 @@ in {
   };
 
   config = with lib; let
-    # Recursively flatten *List objects
-    flattenListObjects = builtins.concatMap (object:
-      if builtins.match "^.*List$" object.kind != null
-      then flattenListObjects object.items
-      else [object]
-    );
     groupedObjects = mapAttrs (_: release:
       {
         resources = [];
@@ -113,7 +107,7 @@ in {
             then "resources"
             else "objects"
         )
-        (flattenListObjects release.objects)))
+        (helpers.flattenListObjects release.objects)))
     config.helm.releases;
 
     allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);

--- a/modules/applications/kustomize.nix
+++ b/modules/applications/kustomize.nix
@@ -94,6 +94,12 @@ in {
   };
 
   config = with lib; let
+    # Recursively flatten *List objects
+    flattenListObjects = builtins.concatMap (object:
+      if builtins.match "^.*List$" object.kind != null
+      then flattenListObjects object.items
+      else [object]
+    );
     groupedObjects = mapAttrs (_: release:
       {
         resources = [];
@@ -107,7 +113,7 @@ in {
             then "resources"
             else "objects"
         )
-        release.objects))
+        (flattenListObjects release.objects)))
     config.kustomize.applications;
 
     allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);

--- a/modules/applications/kustomize.nix
+++ b/modules/applications/kustomize.nix
@@ -94,12 +94,6 @@ in {
   };
 
   config = with lib; let
-    # Recursively flatten *List objects
-    flattenListObjects = builtins.concatMap (object:
-      if builtins.match "^.*List$" object.kind != null
-      then flattenListObjects object.items
-      else [object]
-    );
     groupedObjects = mapAttrs (_: release:
       {
         resources = [];
@@ -113,7 +107,7 @@ in {
             then "resources"
             else "objects"
         )
-        (flattenListObjects release.objects)))
+        (helpers.flattenListObjects release.objects)))
     config.kustomize.applications;
 
     allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);

--- a/modules/applications/kustomize.nix
+++ b/modules/applications/kustomize.nix
@@ -107,7 +107,7 @@ in {
             then "resources"
             else "objects"
         )
-        (helpers.flattenListObjects release.objects)))
+        release.objects))
     config.kustomize.applications;
 
     allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);

--- a/modules/applications/lib.nix
+++ b/modules/applications/lib.nix
@@ -14,9 +14,10 @@ with lib; rec {
       then elemAt splitApiVersion 0
       else elemAt splitApiVersion 1;
   };
+
   # Recursively flatten *List objects
   flattenListObjects = builtins.concatMap (object:
-    if builtins.match "^.*List$" object.kind != null
+    if builtins.match "^.*List$" object.kind != null && builtins.isList (object.items or null)
     then flattenListObjects object.items
     else [object]
   );

--- a/modules/applications/lib.nix
+++ b/modules/applications/lib.nix
@@ -1,5 +1,5 @@
 lib:
-with lib; {
+with lib; rec {
   getGVK = object: let
     splitApiVersion = splitString "/" object.apiVersion;
   in {
@@ -14,4 +14,10 @@ with lib; {
       then elemAt splitApiVersion 0
       else elemAt splitApiVersion 1;
   };
+  # Recursively flatten *List objects
+  flattenListObjects = builtins.concatMap (object:
+    if builtins.match "^.*List$" object.kind != null
+    then flattenListObjects object.items
+    else [object]
+  );
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,9 +16,11 @@
       ./helm/transformer.nix
       ./helm/resource-override.nix
       ./helm/extra-opts.nix
+      ./helm/flatten-lists.nix
       ./kustomize/base.nix
       ./kustomize/overlay.nix
       ./kustomize/resource-override.nix
+      ./kustomize/flatten-lists.nix
     ];
   };
 }

--- a/tests/helm/chart/templates/configmaps.yaml
+++ b/tests/helm/chart/templates/configmaps.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMapList
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-1
+  data:
+    key: value
+- apiVersion: v1
+  kind: ConfigMapList
+  items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-2
+    data:
+      key: value
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-3
+    data:
+      key: value

--- a/tests/helm/chart/templates/configmaps.yaml
+++ b/tests/helm/chart/templates/configmaps.yaml
@@ -22,3 +22,11 @@ items:
       name: cm-3
     data:
       key: value
+---
+apiVersion: custom/v1
+kind: CustomList
+metadata:
+  name: custom-list
+spec:
+  items:
+    - 1

--- a/tests/helm/flatten-lists.nix
+++ b/tests/helm/flatten-lists.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  apps = config.applications;
+in {
+  applications.test1.helm.releases.test1 = {
+    chart = ./chart; 
+  };
+
+  test = with lib; {
+    name = "helm chart with nested List object";
+    description = "Create an application with Helm chart, splitting up List objects.";
+    assertions = [
+      {
+        description = "ConfigMaps should be rendered correctly.";
+
+        expression = filter (x: x.kind == "ConfigMap") apps.test1.objects;
+
+        expected = [
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-1";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-2";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-3";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+        ];
+      }
+      {
+        description = "ConfigMapLists should NOT be rendered.";
+
+        expression = filter (x: x.kind == "ConfigMapList") apps.test1.objects;
+
+        expected = [];
+      }
+    ];
+  };
+}

--- a/tests/helm/flatten-lists.nix
+++ b/tests/helm/flatten-lists.nix
@@ -49,6 +49,20 @@ in {
 
         expected = [];
       }
+      {
+        description = "CustomList should be rendered intact.";
+
+        expression = filter (x: x.kind == "CustomList") apps.test1.objects;
+
+        expected = [
+          {
+            apiVersion = "custom/v1";
+            kind = "CustomList";
+            metadata.name = "custom-list";
+            spec.items = [1];
+          }
+        ];
+      }
     ];
   };
 }

--- a/tests/kustomize/flatten-lists.nix
+++ b/tests/kustomize/flatten-lists.nix
@@ -52,6 +52,21 @@ in {
 
         expected = [];
       }
+      {
+        description = "CustomList should be rendered intact.";
+
+        expression = filter (x: x.kind == "CustomList") apps.test1.objects;
+
+        expected = [
+          {
+            apiVersion = "custom/v1";
+            kind = "CustomList";
+            metadata.name = "custom-list";
+            metadata.namespace = "test1";
+            spec.items = [1];
+          }
+        ];
+      }
     ];
   };
 }

--- a/tests/kustomize/flatten-lists.nix
+++ b/tests/kustomize/flatten-lists.nix
@@ -1,0 +1,57 @@
+{
+  lib,
+  config,
+  ...
+}: let
+  apps = config.applications;
+in {
+  applications.test1.kustomize.applications.test1 = {
+    kustomization = {
+      src = ./manifests;
+      path = "base";
+    };
+  };
+
+  test = with lib; {
+    name = "kustomize application with nested List object.";
+    description = "Create an application with kustomize, splitting up List objects.";
+    assertions = [
+      {
+        description = "ConfigMaps should be rendered correctly.";
+
+        expression = filter (x: x.kind == "ConfigMap") apps.test1.objects;
+
+        expected = [
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-1";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-2";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+          {
+            apiVersion = "v1";
+            kind = "ConfigMap";
+            metadata.name = "cm-3";
+            metadata.namespace = "test1";
+            data.key = "value";
+          }
+        ];
+      }
+      {
+        description = "ConfigMapLists should NOT be rendered.";
+
+        expression = filter (x: x.kind == "ConfigMapList") apps.test1.objects;
+
+        expected = [];
+      }
+    ];
+  };
+}

--- a/tests/kustomize/manifests/base/configmaps.yaml
+++ b/tests/kustomize/manifests/base/configmaps.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMapList
+items:
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: cm-1
+  data:
+    key: value
+- apiVersion: v1
+  kind: ConfigMapList
+  items:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-2
+    data:
+      key: value
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: cm-3
+    data:
+      key: value

--- a/tests/kustomize/manifests/base/configmaps.yaml
+++ b/tests/kustomize/manifests/base/configmaps.yaml
@@ -22,3 +22,11 @@ items:
       name: cm-3
     data:
       key: value
+---
+apiVersion: custom/v1
+kind: CustomList
+metadata:
+  name: custom-list
+spec:
+  items:
+    - 1

--- a/tests/kustomize/manifests/base/kustomization.yaml
+++ b/tests/kustomize/manifests/base/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- configmaps.yaml
 - deployment.yaml
 - service.yaml


### PR DESCRIPTION
These are not actual Kubernetes resource definitions and are not validated anyways. They also break evaluation because they do not require a metadata.name property.