### PR TITLE
Propagate testing errors to Github Actions UI

### DIFF
--- a/.github/workflows/cli-shellcheck.yaml
+++ b/.github/workflows/cli-shellcheck.yaml
@@ -25,4 +25,5 @@ jobs:
 
     - name: Run statix
       run: |
-        nix run .#cliTest
+        echo "# Test Results" > $GITHUB_STEP_SUMMARY
+        nix run .#cliTest | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/cli-shellcheck.yaml
+++ b/.github/workflows/cli-shellcheck.yaml
@@ -24,6 +24,7 @@ jobs:
           extra-experimental-features = nix-command flakes
 
     - name: Run statix
+      shell: bash
       run: |
         echo "# Test Results" > $GITHUB_STEP_SUMMARY
         nix run .#cliTest | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/crd2jsonschema-test.yaml
+++ b/.github/workflows/crd2jsonschema-test.yaml
@@ -25,4 +25,5 @@ jobs:
 
     - name: Run crd2jsonschema unit tests
       run: |
-        nix run .#crd2jsonschemaTest
+        echo "# Test Results" > $GITHUB_STEP_SUMMARY
+        nix run .#crd2jsonschemaTest | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/crd2jsonschema-test.yaml
+++ b/.github/workflows/crd2jsonschema-test.yaml
@@ -24,6 +24,7 @@ jobs:
           extra-experimental-features = nix-command flakes
 
     - name: Run crd2jsonschema unit tests
+      shell: bash
       run: |
         echo "# Test Results" > $GITHUB_STEP_SUMMARY
         nix run .#crd2jsonschemaTest | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -22,6 +22,7 @@ jobs:
           extra-experimental-features = nix-command flakes
 
     - name: Run .#libTests
+      shell: bash
       run: |
         echo "# Test Results" > $GITHUB_STEP_SUMMARY
         nix run .#libTests | tee -a $GITHUB_STEP_SUMMARY
@@ -37,6 +38,7 @@ jobs:
           extra-experimental-features = nix-command flakes
 
     - name: Run .#moduleTests
+      shell: bash
       run: |
         echo "# Test Results" > $GITHUB_STEP_SUMMARY
         nix run .#moduleTests | tee -a $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Note the documentation on [workflow exit codes](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference). While the default shell for job steps is in fact bash, there is a difference between the default and explicitly defining `shell: bash`. A clearer description of this difference is [here](https://stackoverflow.com/a/75420766).

Essentially, without `-o pipefail`, the exit code will be 0 (success), even if the test fails, because we pipe the result of the testing commands into `tee` which will always succeed. It isn't clear without further investigation that something is actually wrong with the tests, so setting `-o pipefail` with explicit `shell: bash` will propagate the exit code of the actual testing command to ensure it reflects the actual workflow result.