### PR TITLE
fix: fromCRD handles structural schema rule 1 exceptions

### DIFF
--- a/pkgs/generators/crd/crd2jsonschema.py
+++ b/pkgs/generators/crd/crd2jsonschema.py
@@ -130,14 +130,14 @@ def generate_jsonschema(prefix, files, attr_name_overrides):
 
             # If a definition contains `x-kubernetes-preserve-unknown-fields` without
             # any `type` set, we assume the `type` is `object`.
-            elif (
-                "type" not in definition
-                and definition.get("x-kubernetes-preserve-unknown-fields", False)
-                == True
-            ):
+            elif "type" not in definition:
+              if definition.get("x-kubernetes-preserve-unknown-fields", False)  == True:
                 definition["type"] = "object"
                 return definition
-
+              if definition.get("x-kubernetes-int-or-string", False) == True:
+                definition["type"] = "string"
+                definition["format"] = "int-or-string"
+                return definition
             # The nix generator doesn't support anyOf
             elif "anyOf" in definition:
                 if definition.get("x-kubernetes-int-or-string", False):


### PR DESCRIPTION
Fixes https://github.com/arnarg/nixidy/issues/48

### TEST

- Test CRD manifest

```yaml
apiVersion: apiextensions.k8s.io/v1
kind: CustomResourceDefinition
metadata:
  name: bars.foo.baz
spec:
  scope: Namespaced
  group: foo.baz
  names:
    kind: Bar
    plural: bars
    shortNames:
      - bar
    singular: bar
  versions:
    - name: v1beta3
      schema:
        openAPIV3Schema:
          properties:
            spec:
              properties:
                node:
                  description: a test node
                  x-kubernetes-int-or-string: true
              required:
                - node
              type: object
          required:
            - spec
          type: object
      served: true
      storage: true
```

#### Failure replication

```bash
$nix build --show-trace .#gen.bar
# ...
error: attribute 'type' missing
at /nix/store/67bvmrzr4iin6fcvnz9qavr2fya9hnwm-source/pkgs/generators/crd/jsonschema.nix:154:29:
  153|                     # if property has an array type
  154|                     else if property.type == "array"
     |                             ^
  155|                     then
# ...
```

- flake.lock
```
    "nixidy": {
      "inputs": {
        "flake-utils": "flake-utils",
        "nix-kube-generators": "nix-kube-generators",
        "nixpkgs": "nixpkgs_2"
      },
      "locked": {
        "lastModified": 1753281262,
        "narHash": "sha256-XZO8SNbjifLzUenfTClpzwBwiOi6OkViZ1DrECqUMHM=",
        "owner": "arnarg",
        "repo": "nixidy",
        "rev": "e7e7685825c6bd62a300bbe3eac09d7352629e92",
        "type": "github"
      },
      "original": {
        "owner": "arnarg",
        "repo": "nixidy",
        "type": "github"
      }
    },
...
```

#### Run against this change

```bash
$nix build .#gen.bar
```
