### PR TITLE
fix: allow _[a-zA-Z]+ string for an attr key.

### DIFF
--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -49,7 +49,7 @@
   moduleToAttrs = with lib;
     value:
       if isAttrs value
-      then mapAttrs (_n: moduleToAttrs) (filterAttrs (n: v: v != null && !(hasPrefix "_" n)) value)
+      then mapAttrs (_n: moduleToAttrs) (filterAttrs (n: v: v != null && !(hasPrefix "_priority" n)) value)
       else if isList value
       then map moduleToAttrs value
       else value;

--- a/tests/configmap.nix
+++ b/tests/configmap.nix
@@ -1,0 +1,30 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  apps = config.applications;
+in
+{
+  applications = {
+    test1.resources.configMaps.cm.data = {
+      "FOO" = "bar";
+      "_BAZ" = "qux";
+    };
+  };
+
+  test = with lib; {
+    name = "configmap data fields";
+    description = "Check if configmap data fields are properly handled";
+    assertions = [
+      {
+        description = "Application `test1` configmap data should include '_BAZ'";
+
+        expression = elemAt apps.test1.objects 0;
+
+        assertion = cm: builtins.hasAttr "_BAZ" cm.data;
+      }
+    ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -6,6 +6,7 @@
       ./defaults.nix
       ./sync-options.nix
       ./compare-options.nix
+      ./configmap.nix
       ./create-namespace.nix
       ./yamls.nix
       ./override-name.nix


### PR DESCRIPTION
### Problem
Please refer to the added test.

### Solution
Only exclude `_priority` instead of `_[a-zA-Z0-9_./]*`.

While the original intention of this exclusion isn't clear from the kubenix origin commit [^1],  Kubernetes allows `[a-zA-Z_.-/][a-zA-Z0-9_.-/]*` for the property names with a few exeception rules, none of which prohibits the underscore prefix regex `_[a-zA-Z0-9.-/]*` [^2].

I infer the purpose being a future proof for some nix-specific internal option fields such as `_priority`. However, as of v1.33.0 k8s version, only `_priority` is defined by the nix generator [^3]. Now that nixidy generates the k8s modules [^4], any additional internal options prefixed with `_` in the future can be coordinated.

[^1]: kubenix first commit: https://github.com/hall/kubenix/commit/cbf84e25a574b9bad1a97e1e29a2d5b2fe7d660a
[^2]: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation
[^3]: k8s jsonschema doesn't define _priority option: https://github.com/search?q=repo%3Ayannh%2Fkubernetes-json-schema+path%3A%2F%5Ev1%5C.33%5C.0%5C%2F%2F++_priority&type=code 
[^4]: https://github.com/arnarg/nixidy/blob/main/docs/developer_guide/architecture.md?plain=1#L82