### PR TITLE
feat: Implement Application.spec.destination.name

### DIFF
--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -234,8 +234,16 @@ in
       };
     };
     destination = {
+      name = mkOption {
+        type = types.nullOr types.str;
+        default = nixidyDefaults.destination.name;
+        defaultText = literalExpression "config.nixidy.defaults.destination.name";
+        description = ''
+          The name of the cluster that ArgoCD should deploy all applications to.
+        '';
+      };
       server = mkOption {
-        type = types.str;
+        type = types.nullOr types.str;
         default = nixidyDefaults.destination.server;
         defaultText = literalExpression "config.nixidy.defaults.destination.server";
         description = ''

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -4,6 +4,7 @@
 
     tests = [
       ./defaults.nix
+      ./destination.nix
       ./sync-options.nix
       ./compare-options.nix
       ./configmap.nix

--- a/tests/destination.nix
+++ b/tests/destination.nix
@@ -1,0 +1,46 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  applications = {
+    # Create an application that does not override
+    # any defaults
+    test1.resources.namespaces.test1 = { };
+
+    # Create an applicaton that sets the server
+    test2 = {
+      destination.server = "https://localhost:6443";
+    };
+
+    # Create an applicaton that sets the name
+    test3 = {
+      destination.name = "in-cluster";
+    };
+  };
+
+  test = with lib; {
+    name = "destination";
+    description = "Check that destination get set on all generated applications.";
+    assertions = [
+      {
+        description = "Applications with no overrides gets the default server";
+        expression = config.applications.apps.resources.applications.test1.spec;
+        assertion =
+          spec: spec.destination.name == null && spec.destination.server == "https://kubernetes.default.svc";
+      }
+      {
+        description = "Applications with custom server gets the correct server";
+        expression = config.applications.apps.resources.applications.test2.spec;
+        assertion =
+          spec: spec.destination.name == null && spec.destination.server == "https://localhost:6443";
+      }
+      {
+        description = "Applications with name gets the name without server";
+        expression = config.applications.apps.resources.applications.test3.spec;
+        assertion = spec: spec.destination.name == "in-cluster" && spec.destination.server == null;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
An ArgoCD application can be configured to deploy using a server url OR a cluster name according to the spec[0]. This change implements the logic without changing the current default of using "https://kubernetes.default.svc" as the server; By setting the name attribute, the server will not be used.

[0]: https://argo-cd.readthedocs.io/en/stable/user-guide/application-specification/