### PR TITLE
feat: Allow setting the destination of appOfApps bootstrap

### DIFF
--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -154,6 +154,24 @@ in
         default = "default";
         description = "The project of the generated bootstrap app for appOfApps";
       };
+      destination = {
+        name = mkOption {
+          type = types.nullOr types.str;
+          default = cfg.defaults.destination.name;
+          defaultText = literalExpression "config.nixidy.defaults.destination.name";
+          description = ''
+            The name of the cluster that ArgoCD should deploy the app of apps to.
+          '';
+        };
+        server = mkOption {
+          type = types.nullOr types.str;
+          default = cfg.defaults.destination.server;
+          defaultText = literalExpression "config.nixidy.defaults.destination.server";
+          description = ''
+            The Kubernetes server that ArgoCD should deploy the app of apps to.
+          '';
+        };
+      };
     };
 
     charts = mkOption {
@@ -259,11 +277,11 @@ in
             };
             destination = lib.mkMerge [
               { inherit (app) namespace; }
-              (lib.mkIf (app.destination.name != null) {
-                inherit (app.destination) name;
+              (lib.mkIf (cfg.appOfApps.destination.name != null) {
+                inherit (cfg.appOfApps.destination) name;
               })
-              (lib.mkIf (app.destination.name == null) {
-                inherit (app.destination) server;
+              (lib.mkIf (cfg.appOfApps.destination.name == null) {
+                inherit (cfg.appOfApps.destination) server;
               })
             ];
             # Maybe this should be configurable but

--- a/tests/appOfApps-custom-appOfApps-destination.nix
+++ b/tests/appOfApps-custom-appOfApps-destination.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  customServer = "https://localhost:6443";
+in
+{
+  nixidy.appOfApps = {
+    # Set the default destination server
+    destination.server = customServer;
+  };
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test1 = { };
+
+  test = with lib; {
+    name = "appOfApps-custom-appOfApps-destination";
+    description = "Check the logic of appOfApps destination vs application destinations.";
+    assertions = [
+      {
+        description = "Custom destination is applied to the appOfApps.";
+        expression = config.applications.__bootstrap.resources.applications.apps.spec;
+        assertion = spec: spec.destination.server == customServer;
+      }
+      {
+        description = "Default destination is applied to the test application.";
+        expression = config.applications.apps.resources.applications.test.spec;
+        assertion = spec: spec.destination.server == "https://kubernetes.default.svc";
+      }
+    ];
+  };
+}

--- a/tests/appOfApps-custom-default-destination.nix
+++ b/tests/appOfApps-custom-default-destination.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  defaultServer = "https://localhost:6443";
+in
+{
+  nixidy.defaults = {
+    # Set the default destination server
+    destination.server = defaultServer;
+  };
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test1 = { };
+
+  test = with lib; {
+    name = "appOfApps-custom-default-destination";
+    description = "Check the logic of appOfApps destination vs application destinations.";
+    assertions = [
+      {
+        description = "Default destination is applied to the appOfApps.";
+        expression = config.applications.__bootstrap.resources.applications.apps.spec;
+        assertion = spec: spec.destination.server == defaultServer;
+      }
+      {
+        description = "Default destination is applied to the test application.";
+        expression = config.applications.apps.resources.applications.test.spec;
+        assertion = spec: spec.destination.server == defaultServer;
+      }
+    ];
+  };
+}

--- a/tests/appOfApps-default-destination.nix
+++ b/tests/appOfApps-default-destination.nix
@@ -1,0 +1,26 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test1 = { };
+
+  test = with lib; {
+    name = "appOfApps-default-destination";
+    description = "Check the logic of appOfApps destination vs application destinations.";
+    assertions = [
+      {
+        description = "Default destination is applied to the appOfApps.";
+        expression = config.applications.__bootstrap.resources.applications.apps.spec;
+        assertion = spec: spec.destination.server == "https://kubernetes.default.svc";
+      }
+      {
+        description = "Default destination is applied to the test application.";
+        expression = config.applications.apps.resources.applications.test.spec;
+        assertion = spec: spec.destination.server == "https://kubernetes.default.svc";
+      }
+    ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3,6 +3,9 @@
     name = "nixidy modules";
 
     tests = [
+      ./appOfApps-default-destination.nix
+      ./appOfApps-custom-default-destination.nix
+      ./appOfApps-custom-appOfApps-destination.nix
       ./defaults.nix
       ./destination.nix
       ./sync-options.nix


### PR DESCRIPTION
In a multi-cluster environment where ArgoCD is installed on a cluster that is different than the cluster for the actual applications; To accomplish that, nixidy.appOfApps.destination.{name,server} options were added.