### PR TITLE
feat: Support append env suffix to all application names

### DIFF
--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -21,6 +21,12 @@ in
       description = "The environment name for this configuration.";
     };
 
+    appendNameWithEnv = mkOption {
+      type = types.bool;
+      default = false;
+      description = "When this is set to true, all applications names will be suffixed by the environment.";
+    };
+
     target = {
       repository = mkOption {
         type = types.str;
@@ -181,7 +187,7 @@ in
 
               value = {
                 metadata = {
-                  inherit (app) name;
+                  name = if cfg.appendNameWithEnv then "${app.name}-${cfg.env}" else app.name;
                   annotations = if app.annotations != { } then app.annotations else null;
                 };
                 spec = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -12,6 +12,8 @@
       ./override-name.nix
       ./internal-apps.nix
       ./no-port-protocol.nix
+      ./no-suffix-env-to-app-name.nix
+      ./suffix-env-to-app-name.nix
       ./templates.nix
       ./helm/no-values.nix
       ./helm/with-values.nix

--- a/tests/no-suffix-env-to-app-name.nix
+++ b/tests/no-suffix-env-to-app-name.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  nixidy = {
+    env = "prod";
+    appendNameWithEnv = false;
+  };
+
+  # Create a a couple of applications
+  applications = {
+    test1 = { };
+    test2 = { };
+  };
+
+  test = with lib; {
+    name = "suffix-env-to-app-name";
+    description = "Check that application name don't get the env as suffix.";
+    assertions = [
+      {
+        description = "All applications should not have the -{env} suffix in their name";
+        expression = config.applications.apps.resources.applications;
+        assertion =
+          expr:
+          let
+            apps = attrsToList expr;
+          in
+          all (app: app.value.metadata.name == app.name) apps;
+      }
+    ];
+  };
+}

--- a/tests/suffix-env-to-app-name.nix
+++ b/tests/suffix-env-to-app-name.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  nixidy = {
+    env = "prod";
+    appendNameWithEnv = true;
+  };
+
+  # Create a a couple of applications
+  applications = {
+    test1 = { };
+    test2 = { };
+  };
+
+  test = with lib; {
+    name = "suffix-env-to-app-name";
+    description = "Check that application name get the env as suffix.";
+    assertions = [
+      {
+        description = "All applications should have the -{env} suffix in their name";
+        expression = config.applications.apps.resources.applications;
+        assertion =
+          expr:
+          let
+            apps = attrsToList expr;
+          in
+          all (app: app.value.metadata.name == "${app.name}-${config.nixidy.env}") apps;
+      }
+    ];
+  };
+}


### PR DESCRIPTION
Setting the flag `nixidy.appendNameWithEnv` to true will cause all applications to have -{env} as suffix in their name to better support multiple environments managed by one ArgoCD cluster.

closes #64 