### PR TITLE
feat(fromCRD): Add support for accept patches

### DIFF
--- a/pkgs/generators/default.nix
+++ b/pkgs/generators/default.nix
@@ -167,6 +167,7 @@ let
     {
       name,
       src,
+      patches ? [ ],
       crds,
       namePrefix ? "",
       attrNameOverrides ? { },
@@ -190,12 +191,13 @@ let
           pythonWithYaml = pkgs.python3.withPackages (ps: [ ps.pyyaml ]);
         in
         pkgs.stdenv.mkDerivation {
-          inherit src;
+          inherit src patches;
 
           name = "${name}-jsonschema.json";
 
           phases = [
             "unpackPhase"
+            "patchPhase"
             "installPhase"
           ];
 


### PR DESCRIPTION
Some repositories have crds with Go template, such as `{{ if .Values.crd.enable }}` which break the fromCRD function. Simply accepting patches for the derivation allows fixing this.

Ideally, we should allow the inner derivation to accept overrides/overlays but this should be helpful enough for now.