### PR TITLE
fix(removeLabels): handle spec.selector.matchLabels for more kinds

### DIFF
--- a/lib/kube.nix
+++ b/lib/kube.nix
@@ -134,9 +134,17 @@
           update = updateFunc;
         }
       )
-      # Handle Deployment selector matchLabels
+      # Handle DaemonSet/Deployment/ReplicaSet/StatefulSet selector matchLabels
       ++ (lib.optional
-        ((manifest.kind == "Deployment") && (hasLabelPath [ "spec" "selector" "matchLabels" ] manifest))
+        (
+          (
+            manifest.kind == "DaemonSet"
+            || manifest.kind == "Deployment"
+            || manifest.kind == "ReplicaSet"
+            || manifest.kind == "StatefulSet"
+          )
+          && (hasLabelPath [ "spec" "selector" "matchLabels" ] manifest)
+        )
         {
           path = [
             "spec"

--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -300,42 +300,54 @@ in
           };
         };
       };
-      testDeploymentMatchLabels = {
-        expr = lib.kube.removeLabels [ "helm.sh/chart" ] {
-          apiVersion = "apps/v1";
-          kind = "Deployment";
-          metadata = {
-            name = "test-deployment";
-            labels = {
-              "app.kubernetes.io/name" = "test";
-              "helm.sh/chart" = "test-chart";
+    }
+    // (builtins.listToAttrs (
+      map
+        (kind: {
+          name = "test${kind}MatchLabels";
+          value = {
+            expr = lib.kube.removeLabels [ "helm.sh/chart" ] {
+              apiVersion = "apps/v1";
+              inherit kind;
+              metadata = {
+                name = "test-${lib.toLower kind}";
+                labels = {
+                  "app.kubernetes.io/name" = "test";
+                  "helm.sh/chart" = "test-chart";
+                };
+              };
+              spec = {
+                replicas = 1;
+                selector.matchLabels = {
+                  "app.kubernetes.io/name" = "test";
+                  "helm.sh/chart" = "test-chart";
+                };
+              };
+            };
+            expected = {
+              apiVersion = "apps/v1";
+              inherit kind;
+              metadata = {
+                name = "test-${lib.toLower kind}";
+                labels = {
+                  "app.kubernetes.io/name" = "test";
+                };
+              };
+              spec = {
+                replicas = 1;
+                selector.matchLabels = {
+                  "app.kubernetes.io/name" = "test";
+                };
+              };
             };
           };
-          spec = {
-            replicas = 1;
-            selector.matchLabels = {
-              "app.kubernetes.io/name" = "test";
-              "helm.sh/chart" = "test-chart";
-            };
-          };
-        };
-        expected = {
-          apiVersion = "apps/v1";
-          kind = "Deployment";
-          metadata = {
-            name = "test-deployment";
-            labels = {
-              "app.kubernetes.io/name" = "test";
-            };
-          };
-          spec = {
-            replicas = 1;
-            selector.matchLabels = {
-              "app.kubernetes.io/name" = "test";
-            };
-          };
-        };
-      };
-    };
+        })
+        [
+          "DaemonSet"
+          "Deployment"
+          "ReplicaSet"
+          "StatefulSet"
+        ]
+    ));
   };
 }


### PR DESCRIPTION
DaemonSet, ReplicaSet, and StatefulSet all have spec.selector.matchLabels that works the same way as a Deployment. Without removing the labels from the matchLabels, the manifest is invalid.