### PR TITLE
feat(flake): Expose module lib as mlib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,11 @@
       flake-utils,
       nix-kube-generators,
     }:
+    let
+      kubelib = nix-kube-generators;
+    in
     {
-      lib = import ./make-env.nix {
-        kubelib = nix-kube-generators;
-      };
+      lib = import ./make-env.nix { inherit kubelib; };
     }
     // (flake-utils.lib.eachDefaultSystem (
       system:
@@ -28,6 +29,8 @@
         packages = import ./nixidy pkgs;
       in
       {
+        mlib = import ./lib { inherit pkgs kubelib; };
+
         packages = {
           default = packages.nixidy;
           cli = pkgs.callPackage ./cli { };


### PR DESCRIPTION
It can be used downstream as 'inputs.nixidy.mlib.${system}'

closes #70