### PR TITLE
feat: Allow setting helm.extraOpts for all applications

### DIFF
--- a/modules/applications/helm.nix
+++ b/modules/applications/helm.nix
@@ -56,7 +56,8 @@ in
                 };
                 extraOpts = mkOption {
                   type = with types; listOf str;
-                  default = [ ];
+                  default = nixidyDefaults.helm.extraOpts;
+                  defaultText = literalExpression "config.nixidy.defaults.helm.extraOpts";
                   example = [ "--no-hooks" ];
                   description = ''
                     Extra options to pass to `helm template` that is run when rendering the helm chart.

--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -55,18 +55,29 @@ in
     };
 
     defaults = {
-      helm.transformer = mkOption {
-        type = with types; functionTo (listOf (attrsOf anything));
-        default = res: res;
-        defaultText = literalExpression "res: res";
-        example = literalExpression ''
-          map (lib.kube.removeLabels ["helm.sh/chart"])
-        '';
-        description = ''
-          Function that will be applied to the list of rendered manifests after the helm templating.
-          This option applies to all helm releases in all applications unless explicitly specified
-          there.
-        '';
+      helm = {
+        extraOpts = mkOption {
+          type = with types; listOf str;
+          default = [ ];
+          example = [ "--no-hooks" ];
+          description = ''
+            The default extra options to pass to `helm template` that is run
+            when rendering the helm chart, applies to all applications.
+          '';
+        };
+        transformer = mkOption {
+          type = with types; functionTo (listOf (attrsOf anything));
+          default = res: res;
+          defaultText = literalExpression "res: res";
+          example = literalExpression ''
+            map (lib.kube.removeLabels ["helm.sh/chart"])
+          '';
+          description = ''
+            Function that will be applied to the list of rendered manifests after the helm templating.
+            This option applies to all helm releases in all applications unless explicitly specified
+            there.
+          '';
+        };
       };
 
       kustomize.transformer = mkOption {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,7 @@
       ./helm/transformer.nix
       ./helm/resource-override.nix
       ./helm/extra-opts.nix
+      ./helm/extra-opts-defaults.nix
       ./helm/flatten-lists.nix
       ./kustomize/base.nix
       ./kustomize/overlay.nix

--- a/tests/helm/chart/templates/servicemonitor.yaml
+++ b/tests/helm/chart/templates/servicemonitor.yaml
@@ -1,0 +1,21 @@
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "chart.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "chart.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path | default "/metrics" }}
+      interval: {{ .Values.serviceMonitor.interval | default "30s" }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout | default "10s" }}
+{{- end }}

--- a/tests/helm/chart/values.yaml
+++ b/tests/helm/chart/values.yaml
@@ -10,3 +10,5 @@ service:
 
 issuer:
   create: false
+
+serviceMonitor: {}

--- a/tests/helm/extra-opts-defaults.nix
+++ b/tests/helm/extra-opts-defaults.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  apps = config.applications;
+in
+{
+  nixidy.defaults.helm.extraOpts = [ "--api-versions=monitoring.coreos.com/v1" ];
+
+  # Create an application with a helm chart.
+  applications.test1.helm.releases.test1 = {
+    chart = ./chart;
+  };
+
+  test = with lib; {
+    name = "helm chart with defaults extra opts";
+    description = "Create an application with Helm chart and default extra opts.";
+    assertions = [
+      {
+        description = "ServiceMonitor should be rendered correctly.";
+
+        expression = findFirst (
+          x: x.kind == "ServiceMonitor" && x.metadata.name == "test1-chart"
+        ) null apps.test1.objects;
+
+        expected = {
+          apiVersion = "monitoring.coreos.com/v1";
+          kind = "ServiceMonitor";
+          metadata = {
+            name = "test1-chart";
+            namespace = "test1";
+            labels = {
+              "app.kubernetes.io/instance" = "test1";
+              "app.kubernetes.io/managed-by" = "Helm";
+              "app.kubernetes.io/name" = "chart";
+              "app.kubernetes.io/version" = "1.16.0";
+              "helm.sh/chart" = "chart-0.1.0";
+            };
+          };
+          spec = {
+            selector.matchLabels = {
+              "app.kubernetes.io/instance" = "test1";
+              "app.kubernetes.io/name" = "chart";
+            };
+            namespaceSelector.matchNames = [ "test1" ];
+            endpoints = [
+              {
+                port = "http";
+                path = "/metrics";
+                interval = "30s";
+                scrapeTimeout = "10s";
+              }
+            ];
+          };
+        };
+      }
+    ];
+  };
+}

--- a/tests/helm/extra-opts.nix
+++ b/tests/helm/extra-opts.nix
@@ -119,6 +119,16 @@ in
 
         expected = null;
       }
+
+      {
+        description = "ServiceMonitor should not be rendered at all.";
+
+        expression = findFirst (
+          x: x.kind == "ServiceMonitor" && x.metadata.name == "test1-chart"
+        ) null apps.test1.objects;
+
+        expected = null;
+      }
     ];
   };
 }


### PR DESCRIPTION
This allows me to configure `--api-versions` for each cluster ensuring that the "helm template" command run in the same way that ArgoCD would typically run it to generate the template.

Tip for extracting all the api-versions of a cluster:

```bash
for gv in $(kubectl api-versions); do
  # 1. Output the base Group/Version (e.g., --api-versions apps/v1)
  echo "--api-versions $gv"

  # Determine the raw API path
  # Core API (v1) is at /api/v1; named groups are at /apis/<group>/<version>
  if [[ "$gv" == "v1" ]]; then
      path="/api/v1"
  else
      path="/apis/$gv"
  fi

  # 2. Query the API server for all resources in this version
  # - Filter out subresources (containing "/")
  # - Format as --api-versions Group/Version/Kind
  k get --raw "$path" | jq -r --arg gv "$gv" '
      .resources[]?
      | select(.name | contains("/") | not)
      | "--api-versions " + $gv + "/" + .kind
  '
done
```