### PR TITLE
feat: Support specifying an ArgoCD finalizer

### DIFF
--- a/modules/applications/default.nix
+++ b/modules/applications/default.nix
@@ -140,6 +140,18 @@ in
         description = "Sets IgnoreExtraneous compare option for the application. Only setting it as `true` has any effect.";
       };
     };
+    finalizer = mkOption {
+      type = types.enum [
+        "background"
+        "foreground"
+        "non-cascading"
+      ];
+      default = nixidyDefaults.finalizer;
+      defaultText = literalExpression "config.nixidy.defaults.finalizer";
+      description = ''
+        Specify the finalizer to apply to the ArgoCD application.
+      '';
+    };
     syncPolicy = {
       autoSync = {
         enable = mkOption {

--- a/tests/appOfApps-default-finalizer-background.nix
+++ b/tests/appOfApps-default-finalizer-background.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  nixidy.defaults.finalizer = "background";
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test = { };
+
+  test = with lib; {
+    name = "appOfApps-default-finalizer-background";
+    description = "Validate the finalizer of the appOfApps.";
+    assertions = [
+      {
+        description = "The finalizer is set to background";
+        expression = config.applications.__bootstrap.resources.applications.apps;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io/background" ];
+      }
+    ];
+  };
+}

--- a/tests/appOfApps-finalizer-background.nix
+++ b/tests/appOfApps-finalizer-background.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  applications.${config.nixidy.appOfApps.name}.finalizer = "background";
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test = { };
+
+  test = with lib; {
+    name = "appOfApps-finalizer-background";
+    description = "Validate the finalizer of the appOfApps.";
+    assertions = [
+      {
+        description = "The finalizer is set to background";
+        expression = config.applications.__bootstrap.resources.applications.apps;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io/background" ];
+      }
+    ];
+  };
+}

--- a/tests/appOfApps-finalizer-foreground.nix
+++ b/tests/appOfApps-finalizer-foreground.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  applications.${config.nixidy.appOfApps.name}.finalizer = "foreground";
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test = { };
+
+  test = with lib; {
+    name = "appOfApps-finalizer-foreground";
+    description = "Validate the finalizer of the appOfApps.";
+    assertions = [
+      {
+        description = "The finalizer is set to foreground";
+        expression = config.applications.__bootstrap.resources.applications.apps;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io" ];
+      }
+    ];
+  };
+}

--- a/tests/appOfApps-finalizer-non-cascading.nix
+++ b/tests/appOfApps-finalizer-non-cascading.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  applications.${config.nixidy.appOfApps.name}.finalizer = "non-cascading";
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test = { };
+
+  test = with lib; {
+    name = "appOfApps-finalizer-non-cascading";
+    description = "Validate the finalizer of the appOfApps.";
+    assertions = [
+      {
+        description = "No finalizers listed in the app.";
+        expression = config.applications.__bootstrap.resources.applications.apps;
+        assertion = app: app.metadata.finalizers == null;
+      }
+    ];
+  };
+}

--- a/tests/argo-default-finalizer-background.nix
+++ b/tests/argo-default-finalizer-background.nix
@@ -1,0 +1,23 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  nixidy.defaults.finalizer = "background";
+
+  # Create an application with everything default.
+  applications.test.resources.namespaces.test = { };
+
+  test = with lib; {
+    name = "argo-default-finalizer-background";
+    description = "Validate the finalizer of the application.";
+    assertions = [
+      {
+        description = "The finalizer is set to background";
+        expression = config.applications.apps.resources.applications.test;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io/background" ];
+      }
+    ];
+  };
+}

--- a/tests/argo-finalizer-background.nix
+++ b/tests/argo-finalizer-background.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  # Create an application with everything default.
+  applications.test.finalizer = "background";
+
+  test = with lib; {
+    name = "argo-finalizer-background";
+    description = "Validate the finalizer of the application.";
+    assertions = [
+      {
+        description = "The finalizer is set to background";
+        expression = config.applications.apps.resources.applications.test;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io/background" ];
+      }
+    ];
+  };
+}

--- a/tests/argo-finalizer-foreground.nix
+++ b/tests/argo-finalizer-foreground.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  # Create an application with everything default.
+  applications.test.finalizer = "foreground";
+
+  test = with lib; {
+    name = "argo-finalizer-foreground";
+    description = "Validate the finalizer of the application.";
+    assertions = [
+      {
+        description = "The finalizer is set to foreground";
+        expression = config.applications.apps.resources.applications.test;
+        assertion = app: app.metadata.finalizers == [ "resources-finalizer.argocd.argoproj.io" ];
+      }
+    ];
+  };
+}

--- a/tests/argo-finalizer-non-cascading.nix
+++ b/tests/argo-finalizer-non-cascading.nix
@@ -1,0 +1,21 @@
+{
+  lib,
+  config,
+  ...
+}:
+{
+  # Create an application with everything default.
+  applications.test.finalizer = "non-cascading";
+
+  test = with lib; {
+    name = "argo-finalizer-non-cascading";
+    description = "Validate the finalizer of the application.";
+    assertions = [
+      {
+        description = "The finalizer is set to non-cascading";
+        expression = config.applications.apps.resources.applications.test;
+        assertion = app: app.metadata.finalizers == null;
+      }
+    ];
+  };
+}

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -7,6 +7,10 @@
       ./appOfApps-custom-default-destination.nix
       ./appOfApps-custom-project.nix
       ./appOfApps-custom-appOfApps-destination.nix
+      ./appOfApps-default-finalizer-background.nix
+      ./appOfApps-finalizer-background.nix
+      ./appOfApps-finalizer-foreground.nix
+      ./appOfApps-finalizer-non-cascading.nix
       ./defaults.nix
       ./destination.nix
       ./sync-options.nix
@@ -14,6 +18,10 @@
       ./configmap.nix
       ./create-namespace.nix
       ./limits.nix
+      ./argo-default-finalizer-background.nix
+      ./argo-finalizer-background.nix
+      ./argo-finalizer-foreground.nix
+      ./argo-finalizer-non-cascading.nix
       ./argo-syncpolicy-managed-namespace-metadata.nix
       ./argo-syncpolicy-retry.nix
       ./yamls.nix


### PR DESCRIPTION
Specifying a finalizer allows ArgoCD to either ignore resources, delete them while keeping the application active or just handle them in the background. This is well documented in https://argo-cd.readthedocs.io/en/latest/user-guide/app_deletion/