### PR TITLE
fix: The bootstrap application should not get environment suffix

### DIFF
--- a/modules/nixidy.nix
+++ b/modules/nixidy.nix
@@ -8,7 +8,11 @@ let
 
   mkApplication = app: {
     metadata = {
-      name = if cfg.appendNameWithEnv then "${app.name}-${cfg.env}" else app.name;
+      name =
+        if (cfg.appendNameWithEnv && cfg.appOfApps.name != app.name) then
+          "${app.name}-${cfg.env}"
+        else
+          app.name;
       annotations = if app.annotations != { } then app.annotations else null;
     };
     spec = {

--- a/tests/suffix-env-to-app-name.nix
+++ b/tests/suffix-env-to-app-name.nix
@@ -29,6 +29,12 @@
           in
           all (app: app.value.metadata.name == "${app.name}-${config.nixidy.env}") apps;
       }
+
+      {
+        description = "The app of apps should not get the suffix.";
+        expression = config.applications.__bootstrap.resources.applications.${config.nixidy.appOfApps.name};
+        assertion = app: app.metadata.name == config.nixidy.appOfApps.name;
+      }
     ];
   };
 }


### PR DESCRIPTION
In 73493866e4dd14eec87d7cc4aba929ed821414a9, mkApplication was created to consolidate the creation of an application but it has changed the behavior of the bootstrap application name as it started honoring config.nixidy.appendNameWithEnv and that broke the behavior of config.nixidy.bootstrapManifest.enable:

```
❯ nixidy switch .#prod
switching manifests
symlink has no referent: "/nix/store/is7lk9ng28mywwr2ba405x8fcak50bxs-nixidy-environment-prod/bootstrap.yaml"
❯ ls -la /nix/store/is7lk9ng28mywwr2ba405x8fcak50bxs-nixidy-environment-prod/bootstrap.yaml
lrwxr-xr-x - root 31 Dec  1969 /nix/store/is7lk9ng28mywwr2ba405x8fcak50bxs-nixidy-environment-prod/bootstrap.yaml -> /nix/store/6z6d77r4gw2dd68xn1ylrk5y9gakd9zv-nixidy-app-__bootstrap/Application-cluster-prod.yaml
❯ ls -la /nix/store/6z6d77r4gw2dd68xn1ylrk5y9gakd9zv-nixidy-app-*
.r--r--r-- 540 root 31 Dec  1969 Application-cluster-prod-prod.yaml
```

As demonstrated above, the app of apps became known on disk as Application-cluster-prod-prod.yaml instead of its original/expected name Application-cluster-prod.yaml which caused the symlink to break and hence nixidy switch no longer worked when both appendNameWithEnv and bootstrapManifest.enable are set to true.