### PR TITLE
fix handling of additionalProperties in JSON schema generation

### DIFF
--- a/pkgs/generators/crd2jsonschema.py
+++ b/pkgs/generators/crd2jsonschema.py
@@ -100,20 +100,20 @@ def generate_jsonschema(prefix, files, attr_name_overrides):
             if "type" in definition and definition["type"] == "object":
                 if "properties" not in definition:
                     if "additionalProperties" in definition:
-                        if "anyOf" in definition["additionalProperties"]:
-                            if definition["additionalProperties"].get(
-                                "x-kubernetes-int-or-string", False
-                            ):
-                                # Patch the definition based on the custom x-kubernetes-int-or-string
-                                definition["additionalProperties"] = {
-                                    "type": "string",
-                                    "format": "int-or-string",
-                                }
-                            else:
-                                # The nix generator doesn't support anyOf
-                                definition["additionalProperties"] = definition[
-                                    "additionalProperties"
-                                ]["anyOf"][0]
+                        if definition["additionalProperties"].get(
+                            "x-kubernetes-int-or-string", False
+                        ):
+                            # Patch the definition based on the custom x-kubernetes-int-or-string
+                            definition["additionalProperties"] = {
+                                "type": "string",
+                                "format": "int-or-string",
+                            }
+                        elif "anyOf" in definition["additionalProperties"]:
+                            # The nix generator doesn't support anyOf
+                            definition["additionalProperties"] = definition[
+                                "additionalProperties"
+                            ]["anyOf"][0]
+                    
 
                         # If additionalProperties only contains 'x-kubernetes-preserve-unknown-fields'
                         # we can just drop the `additionalProperties` entirely and the generator


### PR DESCRIPTION
Hey,

i found a bug when generating crds for the crunch-data/pgo chart. I think there happened a switch-up of the "anyOf" condition.
it was generating the "type" and "format" patch, which is required in `generator.nix`, only when additionalProperties.anyOf was set.

can be tested with:
```ǹix
nixidy.packages.generators.fromChartCRD {
  name = "pgo";
  chartAttrs = {
    chart = "pgo";
    repo = "oci://registry.developers.crunchydata.com/crunchydata";
    version = "6.0.0";
    chartHash = "sha256-4O+qzsCz/NiYbBc0QTsOA0QFx2FkG472QlmhegnpFsg=";
  };
};
```

all my other charts still seem to work fine.

