### PR TITLE
fix(generators): escape ${...} in generated Nix string literals

### DIFF
--- a/pkgs/generators/generator.nix
+++ b/pkgs/generators/generator.nix
@@ -18,17 +18,21 @@ let
     in
     lib.fix (lib.extends overlay f);
 
+  # Escape ${...} sequences so they appear as literal text in generated
+  # Nix "..." strings instead of being parsed as string interpolations.
+  escapeNixStr = str: builtins.replaceStrings [ "\${" ] [ "\\$\{" ] str;
+
   gen = rec {
-    mkMerge = values: ''mkMerge [${concatMapStrings (value: "
+    mkMerge = values: "mkMerge [${concatMapStrings (value: "
       ${value}
-    ") values}]'';
+    ") values}]";
 
     toNixString =
       value:
       if isAttrs value || isList value then
-        builtins.toJSON value
+        escapeNixStr (builtins.toJSON value)
       else if isString value then
-        ''"${value}"''
+        ''"${escapeNixStr value}"''
       else if value == null then
         "null"
       else
@@ -47,10 +51,12 @@ let
       }:
       removeEmptyLines ''
         mkOption {
-              ${optionalString (description != null) "description = ${builtins.toJSON description};"}
-              ${optionalString (type != null) ''type = ${type};''}
-              ${optionalString (default != null) ''default = ${toNixString default};''}
-              ${optionalString (apply != null) ''apply = ${apply};''}
+              ${optionalString (
+                description != null
+              ) "description = ${escapeNixStr (builtins.toJSON description)};"}
+              ${optionalString (type != null) "type = ${type};"}
+              ${optionalString (default != null) "default = ${toNixString default};"}
+              ${optionalString (apply != null) "apply = ${apply};"}
             }'';
 
     mkOverride = priority: value: "mkOverride ${toString priority} ${toNixString value}";


### PR DESCRIPTION
## Problem

CRD descriptions containing `${...}` sequences (e.g. CNPG 0.28.0's `${image_root}` placeholder documentation) end up as unescaped Nix string interpolations in the generated `raw.nix` file. This causes `nixfmt`/`alejandra` to reject the file:

```
- ./raw.nix: unexpected TOKEN_ERROR at 32439..32440, wanted any of [TOKEN_L_PAREN, ...]
```

The root cause is that `builtins.toJSON` escapes for JSON but not for Nix — it does not escape `$` before `{`, so `${...}` in description text becomes a string interpolation attempt in the output `.nix` file.

## Fix

Add an `escapeNixStr` helper that replaces `${` with `\${` in strings destined for generated Nix `"..."` literals. Applied in three places:

- `toNixString` for attrs/lists (wraps `builtins.toJSON`)
- `toNixString` for plain strings
- `mkOption` description field

## Reproduction

Any Helm chart whose CRDs have `${...}` in a description will trigger this. The CNPG operator chart 0.28.0 (via nixhelm) is one such chart — it has descriptions like:

> The `${image_root}` placeholder resolves to the absolute mount path of the extension's volume