### PR TITLE
feat: add extraRawYamls for unmodified YAML passthrough

### DIFF
--- a/docs/user_guide/typed_resources.md
+++ b/docs/user_guide/typed_resources.md
@@ -11,6 +11,25 @@ For example:
 
 The lack of availability of typed resource options only hinders the ability to define the resources in nix. Any manifests that are rendered from a Helm Chart or defined in `applications.<applicationName>.yamls` and do not have defined resource options for that group, version and kind will go straight to the output for the application and can not be patched by nixidy.
 
+## Including arbitrary YAML
+
+To include YAML files in an application's output without nixidy parsing them, use `applications.<applicationName>.extraRawYamls`. The listed files are copied into the application's output directory and are never round-tripped through `kube.fromYAML`, so they are not available under `resources` and cannot be patched in nix.
+
+A common use case is [SOPS](https://github.com/getsops/sops)-encrypted manifests: the top-level `sops` metadata block would otherwise be stripped, and `ENC[...]` ciphertext values would be re-formatted in ways that break decryption.
+
+```nix
+applications.my-app = {
+  namespace = "my-app";
+
+  extraRawYamls = [ ./encrypted-secret.yaml ];
+};
+```
+
+Each file's basename becomes the output filename. Basenames must be unique within an application and must not collide with typed-resource output filenames (e.g. `Secret-<name>.yaml`); both cases produce build-time assertion failures.
+
+!!! warning
+    `extraRawYamls` is only included in the ArgoCD-targeted environment output. The `kubectl apply --prune` flow produced by [`direct_apply`](./direct_apply.md) only handles typed `objects` and skips raw files. SOPS-encrypted manifests aren't valid Kubernetes objects until decrypted, so they are expected to be applied by ArgoCD (with a SOPS plugin) rather than `kubectl apply`.
+
 ## Generating your own resource options from CRDs
 
 Thankfully a code generator for generating resource options from CRDs is provided by nixidy (this is based heavily on kubenix's code generator).

--- a/modules/applications/yamls.nix
+++ b/modules/applications/yamls.nix
@@ -26,6 +26,23 @@ in
         Can be useful for reading existing YAML files (i.e. `[(builtins.readFile ./deployment.yaml)]`).
       '';
     };
+
+    extraRawYamls = mkOption {
+      type = types.listOf types.path;
+      default = [ ];
+      example = literalExpression ''
+        [ ./encrypted-secret.yaml ]
+      '';
+      description = ''
+        List of YAML files to include in the application's output directory.
+        Each file's basename becomes the output filename.
+
+        Unlike `yamls`, the content is **not** parsed into Nix and therefore cannot be patched through
+        `resources`. This is intended for files that contain fields incompatible with the typed schema;
+        most notably [SOPS](https://github.com/getsops/sops)-encrypted manifests, which carry a top-level
+        `sops` metadata block that would otherwise be stripped or altered by a parse/emit round-trip.
+      '';
+    };
   };
 
   config =
@@ -42,6 +59,13 @@ in
         in
         if config.types ? "${gvk.group}/${gvk.version}/${gvk.kind}" then "resources" else "objects"
       ) (concatMap kube.fromYAML config.yamls));
+
+      rawBasenames = map baseNameOf config.extraRawYamls;
+      duplicateRawBasenames = unique (filter (n: count (m: m == n) rawBasenames > 1) rawBasenames);
+
+      typedFilename = obj: "${obj.kind}-${replaceStrings [ "." ] [ "-" ] obj.metadata.name}.yaml";
+      typedFilenames = map typedFilename config.objects;
+      typedCollisions = filter (n: elem n typedFilenames) (unique rawBasenames);
     in
     {
       inherit (groupedObjects) objects;
@@ -57,5 +81,29 @@ in
           }
         ) groupedObjects.resources
       );
+
+      assertions = optionals (config.extraRawYamls != [ ]) [
+        {
+          assertion = duplicateRawBasenames == [ ];
+          message =
+            "extraRawYamls entries share basename(s): "
+            + concatStringsSep ", " (
+              map (
+                n:
+                "${n} (from: ${
+                  concatStringsSep ", " (map toString (filter (p: baseNameOf p == n) config.extraRawYamls))
+                })"
+              ) duplicateRawBasenames
+            )
+            + ". Each file in extraRawYamls must have a unique basename.";
+        }
+        {
+          assertion = typedCollisions == [ ];
+          message =
+            "extraRawYamls basename(s) collide with typed-resource output filenames: "
+            + concatStringsSep ", " typedCollisions
+            + ". Rename the raw file(s) to avoid overwriting typed manifests.";
+        }
+      ];
     };
 }

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -13,6 +13,11 @@ let
         obj: "${obj.kind}-${builtins.replaceStrings [ "." ] [ "-" ] obj.metadata.name}"
       ) app.objects;
 
+      rawYamlFiles = map (source: {
+        filename = baseNameOf source;
+        inherit source;
+      }) app.extraRawYamls;
+
       writeManifests = ''
         set -e
         out=$1
@@ -45,7 +50,14 @@ let
               EOF
             ''
         ) grouped
-      ));
+      ))
+      + lib.optionalString (rawYamlFiles != [ ]) (
+        "\n"
+        + lib.concatMapStringsSep "\n" (f: ''
+          echo "Writing ${f.filename}"
+          cp ${f.source} "$out/${f.filename}"
+        '') rawYamlFiles
+      );
     in
     pkgs.stdenv.mkDerivation {
       inherit writeManifests;

--- a/modules/testing/default.nix
+++ b/modules/testing/default.nix
@@ -9,6 +9,7 @@ let
     imports = [ ./eval.nix ];
 
     _module.args.applicationImports = config.nixidy.applicationImports;
+    _module.args.pkgs = pkgs;
   };
 in
 {

--- a/modules/testing/eval.nix
+++ b/modules/testing/eval.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  pkgs,
   config,
   applicationImports,
   ...
@@ -61,6 +62,9 @@ let
 
     # Include templates
     ../templates.nix
+
+    # Thread pkgs through so tests can build derivations defined by modules.
+    { _module.args.pkgs = pkgs; }
 
     {
       nixidy = {

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -25,6 +25,7 @@
       ./argo-syncpolicy-managed-namespace-metadata.nix
       ./argo-syncpolicy-retry.nix
       ./yamls.nix
+      ./extra-raw-yamls.nix
       ./override-name.nix
       ./internal-apps.nix
       ./no-port-protocol.nix

--- a/tests/extra-raw-yamls.nix
+++ b/tests/extra-raw-yamls.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  config,
+  ...
+}:
+let
+  apps = config.applications;
+  encryptedSecretFile = ./extra-raw-yamls/encrypted-secret.yaml;
+in
+{
+  applications.demo = {
+    namespace = "demo";
+    resources.configMaps.demo-cm.data.hello = "world";
+    extraRawYamls = [ encryptedSecretFile ];
+  };
+
+  test = with lib; {
+    name = "extra raw yamls";
+    description = ''
+      Verify that `extraRawYamls` includes YAML files in the application output without
+      parsing them into Nix, so manifests with schema-incompatible fields (e.g. SOPS
+      metadata) survive intact.
+    '';
+    assertions = [
+      {
+        description = "Raw YAML path should be retrievable as-is via extraRawYamls.";
+        expression = apps.demo.extraRawYamls;
+        expected = [ encryptedSecretFile ];
+      }
+      {
+        description = "Raw YAML should NOT appear in parsed `objects` (i.e. it isn't routed through kube.fromYAML).";
+        expression = findFirst (
+          x: x.kind or null == "Secret" && x.metadata.name or null == "encrypted-secret"
+        ) null apps.demo.objects;
+        expected = null;
+      }
+      {
+        description = "Typed resources alongside extraRawYamls should still render normally.";
+        expression = findFirst (
+          x: x.kind == "ConfigMap" && x.metadata.name == "demo-cm"
+        ) null apps.demo.objects;
+        expected = {
+          apiVersion = "v1";
+          kind = "ConfigMap";
+          metadata = {
+            name = "demo-cm";
+            namespace = "demo";
+          };
+          data.hello = "world";
+        };
+      }
+      {
+        description = "Built application output should contain the raw YAML file with unmodified contents.";
+        expression = builtins.readFile (
+          config.build.environmentPackage + "/${apps.demo.output.path}/encrypted-secret.yaml"
+        );
+        expected = builtins.readFile encryptedSecretFile;
+      }
+    ];
+  };
+}

--- a/tests/extra-raw-yamls/encrypted-secret.yaml
+++ b/tests/extra-raw-yamls/encrypted-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: encrypted-secret
+  namespace: demo
+type: Opaque
+data:
+  password: ENC[AES256_GCM,data:abc=,iv:def=,tag:ghi=,type:str]
+sops:
+  age:
+    - recipient: age1examplerecipient
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        encrypted-key-here
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-05-12T00:00:00Z"
+  mac: ENC[AES256_GCM,data:mac-here,type:str]
+  version: 3.10.2


### PR DESCRIPTION
Currently Nixidy cannot support e.g. SOPS-encrypted secrets, as they don't match the Kubernetes schemas. Handling all possible cases while maintaining the typing would be unnecessarily complex; we can instead allow for passing YAML files directly to the output, skipping the typed parsing by `kube.fromYAML`.

These extra raw YAMLs are not included in the declarative apply feature, as SOPS-encrypted manifests aren't valid resources to be applied in the first place; applying them manually would require Nixidy to support SOPS directly.