### PR TITLE
feat: add optional kindFilter to fromCRD

### DIFF
--- a/pkgs/generators/crd2jsonschema.py
+++ b/pkgs/generators/crd2jsonschema.py
@@ -43,7 +43,7 @@ def uppercase_first(name):
     return name[0].upper() + name[1:]
 
 
-def generate_jsonschema(prefix, files, attr_name_overrides):
+def generate_jsonschema(prefix, files, attr_name_overrides, kind_filter=None):
     schema = {"definitions": {}, "roots": {}}
 
     # This lovely hack is here to circumvent an issue with
@@ -57,13 +57,22 @@ def generate_jsonschema(prefix, files, attr_name_overrides):
             docs = yaml.safe_load_all(f)
 
             for data in docs:
+                # yaml.safe_load_all yields None for empty or comment-only
+                # documents (common in `helm template` output). Skip them so
+                # callers can pass raw multi-document streams directly.
+                if data is None:
+                    continue
                 if (
                     "spec" in data
                     and "kind" in data
                     and data["kind"] == "CustomResourceDefinition"
                 ):
-                    group = data["spec"]["group"]
                     kind = data["spec"]["names"]["kind"]
+                    # When a kind filter is supplied, only generate schemas for
+                    # the listed kinds. An empty/unset filter keeps every CRD.
+                    if kind_filter and kind not in kind_filter:
+                        continue
+                    group = data["spec"]["group"]
                     plural = data["spec"]["names"]["plural"]
                     namespaced = (
                         "scope" in data["spec"]
@@ -234,6 +243,9 @@ if __name__ == "__main__":
     prefix = options.get("namePrefix", "")
     files = options.get("crds", [])
     attr_name_overrides = options.get("attrNameOverrides", {})
+    kind_filter = options.get("kindFilter", [])
 
-    schema = generate_jsonschema(prefix, files, attr_name_overrides)
+    schema = generate_jsonschema(
+        prefix, files, attr_name_overrides, kind_filter=kind_filter
+    )
     print(json.dumps(schema, indent=2))

--- a/pkgs/generators/default.nix
+++ b/pkgs/generators/default.nix
@@ -184,11 +184,21 @@ let
       namePrefix ? "",
       attrNameOverrides ? { },
       skipCoerceToList ? { },
+      # Optional list of CRD `kind` names to generate. When empty (the
+      # default) every CustomResourceDefinition found in `crds` is generated.
+      # Useful when `crds` points at a multi-document stream (e.g. raw
+      # `helm template` output) containing more kinds than you want.
+      kindFilter ? [ ],
     }:
     let
       options = pkgs.writeText "${name}-crd2jsonschema-options.json" (
         builtins.toJSON {
-          inherit crds namePrefix attrNameOverrides;
+          inherit
+            crds
+            namePrefix
+            attrNameOverrides
+            kindFilter
+            ;
         }
       );
 

--- a/pkgs/generators/test_crd2jsonschema.py
+++ b/pkgs/generators/test_crd2jsonschema.py
@@ -996,6 +996,169 @@ metadata:
 
         self.assertEqual(schema, expected_schema)
 
+    def test_kind_filter_keeps_only_listed_kinds(self):
+        # A manifest stream with two CRDs; the filter keeps only one of them.
+        mock_crd_content = """
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foobars.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: FooBar
+    plural: foobars
+    singular: foobar
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: seconds.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: Second
+    plural: seconds
+    singular: second
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+"""
+
+        with patch("builtins.open", mock_open(read_data=mock_crd_content)):
+            schema = generate_jsonschema(
+                "", ["/fake/path/crd.yaml"], {}, kind_filter=["FooBar"]
+            )
+
+        self.assertIn("stable.example.com.v1.FooBar", schema["definitions"])
+        self.assertNotIn("stable.example.com.v1.Second", schema["definitions"])
+        self.assertEqual(
+            list(schema["roots"].keys()), ["stable.example.com.v1.FooBar"]
+        )
+
+    def test_empty_kind_filter_keeps_all_kinds(self):
+        # An empty filter is equivalent to no filter: every CRD is generated.
+        mock_crd_content = """
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foobars.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: FooBar
+    plural: foobars
+    singular: foobar
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: seconds.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: Second
+    plural: seconds
+    singular: second
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+"""
+
+        with patch("builtins.open", mock_open(read_data=mock_crd_content)):
+            schema = generate_jsonschema(
+                "", ["/fake/path/crd.yaml"], {}, kind_filter=[]
+            )
+
+        self.assertIn("stable.example.com.v1.FooBar", schema["definitions"])
+        self.assertIn("stable.example.com.v1.Second", schema["definitions"])
+
+    def test_skips_none_documents(self):
+        # Comment-only/empty documents parse to None (common in
+        # `helm template` output) and must be skipped rather than raising.
+        mock_crd_content = """
+# This leading document is a comment only and parses to None.
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: foobars.stable.example.com
+spec:
+  group: stable.example.com
+  names:
+    kind: FooBar
+    plural: foobars
+    singular: foobar
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+"""
+
+        schema = mock_generate_jsonschema(mock_crd_content, "", {})
+
+        self.assertIn("stable.example.com.v1.FooBar", schema["definitions"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Adds an optional `kindFilter` argument to `fromCRD` — a list of CRD `kind`
names. When non-empty, only `CustomResourceDefinition`s whose
`spec.names.kind` is in the list are generated. The default `[ ]` keeps every
CRD found, so this is fully backwards compatible.

This mirrors what `fromChartCRD` already does with its `crds` argument, but for
the `src`-based `fromCRD` path.

## Motivation

`fromCRD`'s `crds` argument is a list of YAML *files*. When one of those files
is a multi-document stream — e.g. raw `helm template --include-crds` output, or
an upstream bundle that ships many CRDs in one file — you often want types for
only a subset of the kinds it contains, and no way to narrow that existed on
the `src` path. `kindFilter` provides it.

While supporting that, `crd2jsonschema.py` also learned to **skip null
documents** — empty or comment-only YAML docs, which `yaml.safe_load_all`
yields as `None`. These are common in `helm template` output and previously
made the generator raise; skipping them lets callers feed raw multi-document
streams to `fromCRD` directly.

## Example

```nix
fromCRD {
  name = "cert-manager";
  src = ./crds;                                # a bundle with many CRDs
  crds = [ "crds.yaml" ];
  kindFilter = [ "Certificate" "Issuer" "ClusterIssuer" ];   # generate only these
}
```

## Compatibility

- `kindFilter` defaults to `[ ]` → no filtering; output identical to today.
- The null-doc skip only avoids a crash on documents that would otherwise
  raise — it changes nothing for valid inputs.

## Tests

Adds `test_crd2jsonschema.py` cases for kind filtering (hit + empty-filter
passthrough) and null-document skipping — `nix run .#crd2jsonschemaTest`.
