### PR TITLE
refactor: dedupe object intake, filename, and version-enum policy

### DIFF
--- a/modules/applications.nix
+++ b/modules/applications.nix
@@ -4,9 +4,17 @@
   ...
 }:
 let
-  versions = lib.mapAttrsToList (
-    version: _: builtins.concatStringsSep "." (lib.lists.sublist 0 2 (builtins.splitVersion version))
-  ) (import ../pkgs/generators/versions.nix);
+  # The selectable Kubernetes versions are exactly the generated resource
+  # modules present in ./generated/k8s (each `nixidy.k8sVersion` value `X.Y`
+  # imports `./generated/k8s/vX.Y.nix`). Deriving the enum from the artifacts on
+  # disk keeps it in sync with what can actually be imported, rather than
+  # reaching into the generator's `versions.nix` acquisition spec.
+  versions = lib.pipe ./generated/k8s [
+    builtins.readDir
+    builtins.attrNames
+    (builtins.filter (lib.hasSuffix ".nix"))
+    (map (n: lib.removeSuffix ".nix" (lib.removePrefix "v" n)))
+  ];
 in
 {
   options = with lib; {

--- a/modules/applications/helm.nix
+++ b/modules/applications/helm.nix
@@ -116,37 +116,9 @@ in
   config =
     with lib;
     let
-      groupedObjects = mapAttrs (
-        _: release:
-        {
-          resources = [ ];
-          objects = [ ];
-        }
-        // (groupBy (
-          object:
-          let
-            gvk = helpers.getGVK object;
-          in
-          if config.types ? "${gvk.group}/${gvk.version}/${gvk.kind}" then "resources" else "objects"
-        ) (helpers.flattenListObjects release.objects))
-      ) config.helm.releases;
-
-      allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);
-      allObjects = flatten (mapAttrsToList (_: groups: groups.objects) groupedObjects);
-    in
-    {
-      resources = mkMerge (
-        map (
-          object:
-          let
-            gvk = helpers.getGVK object;
-          in
-          {
-            ${gvk.group}.${gvk.version}.${gvk.kind}.${object.metadata.name} = object;
-          }
-        ) allResources
+      allObjects = concatMap (release: helpers.flattenListObjects release.objects) (
+        attrValues config.helm.releases
       );
-
-      objects = allObjects;
-    };
+    in
+    helpers.partitionObjects config.types allObjects;
 }

--- a/modules/applications/kustomize.nix
+++ b/modules/applications/kustomize.nix
@@ -106,37 +106,7 @@ in
   config =
     with lib;
     let
-      groupedObjects = mapAttrs (
-        _: release:
-        {
-          resources = [ ];
-          objects = [ ];
-        }
-        // (groupBy (
-          object:
-          let
-            gvk = helpers.getGVK object;
-          in
-          if config.types ? "${gvk.group}/${gvk.version}/${gvk.kind}" then "resources" else "objects"
-        ) release.objects)
-      ) config.kustomize.applications;
-
-      allResources = flatten (mapAttrsToList (_: groups: groups.resources) groupedObjects);
-      allObjects = flatten (mapAttrsToList (_: groups: groups.objects) groupedObjects);
+      allObjects = concatMap (app: app.objects) (attrValues config.kustomize.applications);
     in
-    {
-      resources = mkMerge (
-        map (
-          object:
-          let
-            gvk = helpers.getGVK object;
-          in
-          {
-            ${gvk.group}.${gvk.version}.${gvk.kind}.${object.metadata.name} = object;
-          }
-        ) allResources
-      );
-
-      objects = allObjects;
-    };
+    helpers.partitionObjects config.types allObjects;
 }

--- a/modules/applications/lib.nix
+++ b/modules/applications/lib.nix
@@ -19,4 +19,56 @@ lib: with lib; rec {
     else
       [ object ]
   );
+
+  # Partition a flat list of kubernetes objects into typed `resources` and
+  # untyped `objects`, based on whether each object's GVK is a registered type.
+  #
+  # `types` is the application's `config.types` registry (keyed
+  # `<group>/<version>/<kind>`). Registered objects are returned as an
+  # `mkMerge`-able attrset path (`<group>.<version>.<kind>.<name>`) so they flow
+  # back into the typed `resources` option and can be patched; everything else
+  # is returned as an opaque list. This is the single intake path shared by the
+  # helm, kustomize and yamls modules.
+  #
+  # Type:
+  #   partitionObjects :: AttrSet -> [AttrSet] -> { resources :: Merge; objects :: [AttrSet]; }
+  partitionObjects =
+    types: objects:
+    let
+      grouped = {
+        resources = [ ];
+        objects = [ ];
+      }
+      // builtins.groupBy (
+        object:
+        let
+          gvk = getGVK object;
+        in
+        if types ? "${gvk.group}/${gvk.version}/${gvk.kind}" then "resources" else "objects"
+      ) objects;
+    in
+    {
+      resources = mkMerge (
+        map (
+          object:
+          let
+            gvk = getGVK object;
+          in
+          {
+            ${gvk.group}.${gvk.version}.${gvk.kind}.${object.metadata.name} = object;
+          }
+        ) grouped.resources
+      );
+
+      inherit (grouped) objects;
+    };
+
+  # The filename stem for an object's rendered manifest: `<Kind>-<name>` with
+  # dots in the name replaced by dashes. `build.nix` groups objects by this stem
+  # (one YAML file per stem) and `yamls.nix` appends `.yaml` to detect collisions
+  # with raw passthrough files; both MUST agree, so the policy lives here.
+  #
+  # Type:
+  #   objectBaseName :: AttrSet -> String
+  objectBaseName = object: "${object.kind}-${replaceStrings [ "." ] [ "-" ] object.metadata.name}";
 }

--- a/modules/applications/yamls.nix
+++ b/modules/applications/yamls.nix
@@ -48,39 +48,17 @@ in
   config =
     with lib;
     let
-      groupedObjects = {
-        resources = [ ];
-        objects = [ ];
-      }
-      // (groupBy (
-        object:
-        let
-          gvk = helpers.getGVK object;
-        in
-        if config.types ? "${gvk.group}/${gvk.version}/${gvk.kind}" then "resources" else "objects"
-      ) (concatMap kube.fromYAML config.yamls));
+      partitioned = helpers.partitionObjects config.types (concatMap kube.fromYAML config.yamls);
 
       rawBasenames = map baseNameOf config.extraRawYamls;
       duplicateRawBasenames = unique (filter (n: count (m: m == n) rawBasenames > 1) rawBasenames);
 
-      typedFilename = obj: "${obj.kind}-${replaceStrings [ "." ] [ "-" ] obj.metadata.name}.yaml";
+      typedFilename = obj: "${helpers.objectBaseName obj}.yaml";
       typedFilenames = map typedFilename config.objects;
       typedCollisions = filter (n: elem n typedFilenames) (unique rawBasenames);
     in
     {
-      inherit (groupedObjects) objects;
-
-      resources = mkMerge (
-        map (
-          object:
-          let
-            gvk = helpers.getGVK object;
-          in
-          {
-            ${gvk.group}.${gvk.version}.${gvk.kind}.${object.metadata.name} = object;
-          }
-        ) groupedObjects.resources
-      );
+      inherit (partitioned) objects resources;
 
       assertions = optionals (config.extraRawYamls != [ ]) [
         {

--- a/modules/build.nix
+++ b/modules/build.nix
@@ -37,14 +37,11 @@ let
   transformedObjects =
     app: applyRewrites app.objectTransforms (applyRewrites config.nixidy.objectTransforms app.objects);
 
-  # Sanitize a resource name the same way mkApp does when forming the
-  # on-disk group key / filename.
-  sanitize = n: builtins.replaceStrings [ "." ] [ "-" ] n;
-
   # The on-disk group key / filename stem for an object. mkApp groups objects
   # under this key; post-process rules resolve the matching path from the same
-  # helper so the two never drift.
-  groupKeyOf = obj: "${obj.kind}-${sanitize obj.metadata.name}";
+  # helper, and yamls.nix reuses it to detect raw-passthrough collisions, so the
+  # filename policy lives in exactly one place (applications/lib.nix).
+  groupKeyOf = helpers.objectBaseName;
 
   # All transform rules visible to an app: env rules first, then app rules
   # (chained in that order, matching `applyRewrites`).
@@ -322,6 +319,8 @@ let
         fi
       fi
     '';
+
+  helpers = import ./applications/lib.nix lib;
 
   mkApp =
     app:


### PR DESCRIPTION
Three policies were duplicated across the application modules. Each is extracted to a single source so the copies cannot drift.

- **`partitionObjects`** (`applications/lib.nix`): the GVK-based split of a flat object list into typed `resources` (mkMerge-able) and untyped `objects` was copy-pasted into `helm.nix`, `kustomize.nix` and `yamls.nix` (~35 lines each). All three now call one helper.
- **`objectBaseName`** (`applications/lib.nix`): the `<Kind>-<dashed-name>` filename stem existed as `build.nix`s `groupKeyOf` and again, hand-written, as `yamls.nix`s collision check. `yamls.nix`s raw-passthrough collision assertions are only correct while the two agree, so the stem now lives in one place and `groupKeyOf` delegates to it.
- **`k8sVersion` enum** (`applications.nix`): derive the selectable versions from the generated modules present in `./generated/k8s` instead of importing `pkgs/generators/versions.nix`. The enum now reflects what can actually be imported.

No behavior change. Net -21 lines. `47/47` module tests and `13/13` lib tests pass.