### PR TITLE
chore: change nixfmt package

### DIFF
--- a/pkgs/generators/compile/generator.nix
+++ b/pkgs/generators/compile/generator.nix
@@ -258,7 +258,7 @@ let
 in
 pkgs.runCommand "k8s-${name}-gen.nix"
   {
-    buildInputs = [ pkgs.nixfmt-rfc-style ];
+    buildInputs = [ pkgs.nixfmt ];
   }
   ''
     cat << 'GENERATED' > ./raw.nix


### PR DESCRIPTION
hi, just trying to get rid of this evaluation warning:

```
evaluation warning: nixfmt-rfc-style is now the same as pkgs.nixfmt which should be used instead.
```