### PR TITLE
fix(generators): don't abort eval on ECMAScript CRD patterns

### DIFF
--- a/lib/tests.nix
+++ b/lib/tests.nix
@@ -350,4 +350,86 @@ in
         ]
     ));
   };
+
+  # Regression tests for the ECMAScript-pattern guard in
+  # pkgs/generators/compile/{runtime,generator}.nix. builtins.match compiles a
+  # POSIX ERE and throws an uncatchable error on a pattern it cannot compile;
+  # the guard translates the simple class escapes and otherwise skips, so a CRD
+  # pattern can neither abort evaluation nor reject a value it should accept.
+  withPattern =
+    let
+      rt = import ../pkgs/generators/compile/runtime.nix {
+        lib = pkgs.lib;
+        config = {
+          defaults = [ ];
+        };
+        definitions = { };
+      };
+      # `(withPattern pattern str).check value`. Evaluating this forces
+      # builtins.match for any pattern the guard deems compilable, so a pattern
+      # that wrongly reached builtins.match with an uncompilable regex would
+      # throw here and fail the test rather than pass silently.
+      accepts = pattern: value: (rt.types.withPattern pattern rt.types.str).check value;
+    in
+    {
+      # Class-free patterns are translated (\d \s \w and \/) and validated.
+      testDigitsAccept = {
+        expr = accepts "\\d+" "123";
+        expected = true;
+      };
+      testDigitsReject = {
+        expr = accepts "\\d+" "abc";
+        expected = false;
+      };
+      testSlashTranslated = {
+        expr = accepts "a\\/b" "a/b";
+        expected = true;
+      };
+      testWordClassAccept = {
+        expr = accepts "\\w+" "abc_1";
+        expected = true;
+      };
+      testAnchoredLiteralAccept = {
+        expr = accepts "^foo-bar$" "foo-bar";
+        expected = true;
+      };
+      testAnchoredLiteralReject = {
+        expr = accepts "^foo-bar$" "nope";
+        expected = false;
+      };
+
+      # Patterns POSIX ERE cannot compile are skipped (the option keeps the base
+      # `str` type): they must never abort evaluation and never reject a valid
+      # value. Each previously either crashed eval or mis-validated.
+      testCharacterClassSkipped = {
+        # `[\w.-]+` was mis-translated to a class-in-class that rejected valid
+        # values; skipping it means a valid value is accepted again.
+        expr = accepts "[\\w.-]+" "my-app.v2";
+        expected = true;
+      };
+      testBracketSubSyntaxSkipped = {
+        # `[[:]` opens a POSIX bracket sub-expression and threw at compile time.
+        expr = accepts "[[:]" "anything";
+        expected = true;
+      };
+      testIntervalSkipped = {
+        expr = accepts "a{2,3}" "anything";
+        expected = true;
+      };
+      testUnsupportedEscapeSkipped = {
+        expr = accepts "\\bword\\b" "anything";
+        expected = true;
+      };
+      testLookaroundSkipped = {
+        expr = accepts "(?=x)" "anything";
+        expected = true;
+      };
+      testCidrLikePatternSkipped = {
+        # Cilium-style IP pattern (classes + intervals): skipped, not crashed —
+        # the regression that motivated the fix. A non-matching value is accepted
+        # because the check is skipped, confirming it is not (mis-)validated.
+        expr = accepts "([0-9]{1,3}\\.){3}[0-9]{1,3}" "not-an-ip";
+        expected = true;
+      };
+    };
 }

--- a/pkgs/generators/compile/generator.nix
+++ b/pkgs/generators/compile/generator.nix
@@ -139,10 +139,40 @@ let
           };
         withPattern =
           p: base:
-          lib.types.addCheck base (x: builtins.match p x != null)
-          // {
-            description = "''${base.description} (matching `''${p}`)";
-          };
+          # builtins.match compiles POSIX ERE, but JSON Schema patterns are
+          # ECMAScript, and an unsupported construct makes it throw an uncatchable
+          # error at compile time (tryEval won't rescue it), aborting evaluation.
+          # Since the throw can't be caught we decide statically and conservatively:
+          # translate the class escapes POSIX lacks (`\d`, `\s`, `\w`, negations,
+          # and `\/`) for the simple case, then apply the check ONLY for patterns we
+          # can be sure compile, skipping otherwise. The API server validates the
+          # real pattern regardless. Skip when the original pattern contains a
+          # character class `[…]` (POSIX bracket sub-syntax diverges from ECMAScript
+          # and replaceStrings translation is context-blind inside a class), a brace
+          # `{` (interval divergence), a `(?…)` group, or an unsupported escape (one
+          # that survives peeling off every escape POSIX accepts). Validates only the
+          # class-free subset, but never crashes and never mis-validates.
+          let
+            posixPattern = builtins.replaceStrings
+              [ "\\d" "\\D" "\\s" "\\S" "\\w" "\\W" "\\/" ]
+              [ "[0-9]" "[^0-9]" "[[:space:]]" "[^[:space:]]" "[0-9A-Za-z_]" "[^0-9A-Za-z_]" "/" ]
+              p;
+            peeled = builtins.replaceStrings
+              [ "\\\\" "\\." "\\(" "\\)" "\\[" "\\{" "\\*" "\\+" "\\?" "\\|" "\\^" "\\$" ]
+              [ "" "" "" "" "" "" "" "" "" "" "" "" ]
+              posixPattern;
+            posixCompilable =
+              builtins.match ".*[[{].*" p == null
+              && builtins.match ".*\\(\\?.*" p == null
+              && builtins.match ".*\\\\.*" peeled == null;
+          in
+          if !posixCompilable then
+            base
+          else
+            lib.types.addCheck base (x: builtins.match posixPattern x != null)
+            // {
+              description = "''${base.description} (matching `''${p}`)";
+            };
       };
 
       mkOptionDefault = mkOverride 1001;

--- a/pkgs/generators/compile/runtime.nix
+++ b/pkgs/generators/compile/runtime.nix
@@ -131,10 +131,96 @@ rec {
       };
     withPattern =
       p: base:
-      lib.types.addCheck base (x: builtins.match p x != null)
-      // {
-        description = "${base.description} (matching `${p}`)";
-      };
+      let
+        # `builtins.match` compiles its pattern as a POSIX ERE, but JSON Schema
+        # `pattern`s are ECMAScript. The two dialects diverge in many places, and
+        # an unsupported construct makes `builtins.match` throw an *uncatchable*
+        # error at compile time (`builtins.tryEval` does not rescue it) — for every
+        # value, aborting evaluation of the whole environment. Since the throw
+        # cannot be caught, we must decide *statically* whether a pattern is safe,
+        # and we do so conservatively: translate the class escapes POSIX ERE lacks
+        # (`\d`, `\s`, `\w` and their negations, plus `\/`) for the simple case,
+        # then apply the check ONLY for patterns we can be sure compile, skipping
+        # (returning the base `str`) otherwise. The API server validates the real
+        # pattern regardless, so skipping only forgoes a redundant client check.
+        #
+        # We skip when the original pattern contains any of:
+        #   - a character class `[…]` — POSIX bracket expressions have their own
+        #     sub-syntax (`[[:class:]]`, `[.coll.]`, `[=eq=]`) and rules that
+        #     diverge from ECMAScript, and `replaceStrings`-based escape
+        #     translation is context-blind (it would corrupt an escape *inside* a
+        #     class), so classes are out of scope;
+        #   - a brace `{` — POSIX interval vs. ECMAScript literal-brace divergence;
+        #   - a `(?…)` group — POSIX ERE has no such groups;
+        #   - an unsupported backslash-escape — one that survives peeling off every
+        #     escape POSIX ERE accepts (e.g. `\b`, `\-`, `\:`).
+        # This is a coverage/robustness trade: it validates only the class-free
+        # subset, but never crashes and never mis-validates a valid value. Anything
+        # more (classes, intervals) is left to the API server.
+        posixPattern =
+          builtins.replaceStrings
+            [
+              "\\d"
+              "\\D"
+              "\\s"
+              "\\S"
+              "\\w"
+              "\\W"
+              "\\/"
+            ]
+            [
+              "[0-9]"
+              "[^0-9]"
+              "[[:space:]]"
+              "[^[:space:]]"
+              "[0-9A-Za-z_]"
+              "[^0-9A-Za-z_]"
+              "/"
+            ]
+            p;
+        peeled =
+          builtins.replaceStrings
+            [
+              "\\\\"
+              "\\."
+              "\\("
+              "\\)"
+              "\\["
+              "\\{"
+              "\\*"
+              "\\+"
+              "\\?"
+              "\\|"
+              "\\^"
+              "\\$"
+            ]
+            [
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+              ""
+            ]
+            posixPattern;
+        posixCompilable =
+          builtins.match ".*[[{].*" p == null
+          && builtins.match ".*\\(\\?.*" p == null
+          && builtins.match ".*\\\\.*" peeled == null;
+      in
+      if !posixCompilable then
+        base
+      else
+        lib.types.addCheck base (x: builtins.match posixPattern x != null)
+        // {
+          description = "${base.description} (matching `${p}`)";
+        };
   };
 
   mkOptionDefault = mkOverride 1001;


### PR DESCRIPTION
Fixes #107.

## Problem

Since `5021152` ("enforce JSON Schema validation in CRD option types"), `withPattern` runs `builtins.match pattern value` on every CRD field carrying an OpenAPI `pattern`. Nix's `builtins.match` compiles its argument as a **POSIX Extended Regular Expression**, but JSON Schema / Kubernetes `pattern`s are **ECMAScript**. The two dialects diverge (escapes like `\d`/`\s`/`\/`, brace/interval syntax, `(?…)` groups, bracket sub-expressions), and when a pattern uses a construct POSIX ERE can't compile, `builtins.match` throws `invalid regular expression` — at *compile* time, so it fails for every value, aborting evaluation of the whole environment.

Real-world trigger: Cilium 1.20's `CiliumBGPClusterConfig.spec…peers[].peerAddress` (IPv4/IPv6 validator using `\d`/`\s`), and the common k8s "qualified name" pattern (`…\.…\/…`, rejected at `\/`).

The failure is **not catchable** — `builtins.tryEval (builtins.match "\\d" "x")` still aborts — so a pattern must be judged *statically*, before it reaches `builtins.match`; there is no way to test-compile it at eval time.

## Fix

In `withPattern` (both twins — `runtime.nix` value form and `generator.nix` emitted source), decide statically and **conservatively**:

- **Translate** the class escapes POSIX ERE lacks (`\d \D \s \S \w \W` → POSIX classes, `\/` → `/`) so simple class-free patterns still validate.
- **Apply the check only when the pattern is provably compilable, else skip** (keep the base `str` type). Skip when the pattern contains any of:
  - a character class `[…]` — POSIX bracket expressions have their own sub-syntax (`[[:class:]]`, `[.coll.]`, `[=eq=]`) that diverges from ECMAScript, and `replaceStrings`-based escape translation is context-blind (it corrupts an escape *inside* a class);
  - a brace `{` — POSIX interval vs. ECMAScript literal-brace divergence;
  - a `(?…)` group — POSIX ERE has none;
  - an unsupported backslash-escape — one that survives peeling off every escape POSIX ERE accepts (`\\ \. \( \) \[ \{ \* \+ \? \| \^ \$`), e.g. `\b`, `\-`, `\:`.

Skipping is lossless: the API server validates the real pattern.

### Why so conservative

Earlier drafts tried to *translate* their way to full coverage (validating classes and intervals). Adversarial testing kept finding valid-ECMAScript patterns that slipped the guard and still aborted eval or, worse, silently mis-validated:
- `[[:]` / `[a[:b]` — a `[` nested in a class opens POSIX bracket sub-syntax → throws;
- `[\w.-]+` — the class escape is translated *inside* the class → `[[0-9A-Za-z_].-]+`, which **rejects** valid values like `my-app.v2`.

Reliably reconciling POSIX bracket/interval sub-syntax with ECMAScript using string operations is not feasible. So the guard validates only the class-free subset and defers everything else to the API server. This is a deliberate **coverage-for-robustness** trade: it validates fewer patterns (notably it now *skips* the Cilium IP pattern rather than validating it), but it never crashes and never rejects a value it should accept.

### Soundness boundary

Sound for **any valid-ECMAScript pattern** — verified with an adversarial battery (class escapes, `\/`, `\b`/`\x`/`\1`/`\p{}`, literal/interval braces, lookarounds, nested bracket sub-syntax): every pattern the guard calls compilable actually compiles under `builtins.match` (checked per-pattern in separate processes), and every unsupported one is skipped. A structurally **malformed** regex (e.g. unbalanced parens `a)b`) is out of scope — it is invalid ECMAScript, rejected by the k8s API server's own structural-schema validation, so it can never reach a rendered manifest, and it aborted identically before `5021152`.

### Notes

- `builtins.match`'s escape support is quirky and asymmetric (`\.`/`\(` compile, `\]`/`\}`/`\/` throw), so the backslash gate is an allow-list-by-peeling rather than a block-list.
- No change to the committed generated modules: they predate `5021152` and contain no `withPattern` calls, so only the live CRD path (`runtime.nix`) is exercised today; `generator.nix` is updated in lockstep for the next regeneration.

## Testing

- Added a `withPattern` unit suite to `lib/tests.nix` (12 nix-unit cases): class-free patterns validate (`\d+`, `\w+`, `a\/b`, anchored literals) and reject non-matches; character classes, intervals, `(?…)` groups, unsupported escapes, POSIX bracket sub-syntax, and a Cilium-style CIDR pattern all skip without crashing or rejecting valid values. `nix-unit` → 25/25 pass.
- Reproduced the original crash against Cilium 1.20 CRDs; with this change the whole environment (`activationPackage`) evaluates and builds green.
